### PR TITLE
Require all configs

### DIFF
--- a/lib/teckel.rb
+++ b/lib/teckel.rb
@@ -4,6 +4,7 @@ require "teckel/version"
 
 module Teckel
   class Error < StandardError; end
+  class FrozenConfigError < Teckel::Error; end
 end
 
 require_relative "teckel/config"

--- a/lib/teckel.rb
+++ b/lib/teckel.rb
@@ -5,9 +5,11 @@ require "teckel/version"
 module Teckel
   class Error < StandardError; end
   class FrozenConfigError < Teckel::Error; end
+  class MissingConfigError < Teckel::Error; end
 end
 
 require_relative "teckel/config"
+require_relative "teckel/none"
 require_relative "teckel/operation"
 require_relative "teckel/result"
 require_relative "teckel/operation/results"

--- a/lib/teckel/config.rb
+++ b/lib/teckel/config.rb
@@ -2,8 +2,6 @@
 
 module Teckel
   class Config
-    class FrozenConfigError < Teckel::Error; end
-
     @default_constructor = :[]
     class << self
       def default_constructor(sym_or_proc = nil)

--- a/lib/teckel/config.rb
+++ b/lib/teckel/config.rb
@@ -25,12 +25,12 @@ module Teckel
       end
     end
 
-    # @!visibility protected
+    # @!visibility private
     def initialize
       @config = {}
     end
 
-    # @!visibility protected
+    # @!visibility private
     def for(key, value = nil, &block)
       if value.nil?
         if block
@@ -42,6 +42,19 @@ module Teckel
         raise FrozenConfigError, "Configuration #{key} is already set"
       else
         @config[key] = value
+      end
+    end
+
+    # @!visibility private
+    def freeze
+      @config.freeze
+      super
+    end
+
+    # @!visibility private
+    def dup
+      super.tap do |copy|
+        copy.instance_variable_set(:@config, @config.dup)
       end
     end
   end

--- a/lib/teckel/config.rb
+++ b/lib/teckel/config.rb
@@ -4,6 +4,20 @@ module Teckel
   class Config
     @default_constructor = :[]
     class << self
+      # @!attribute [r] default_constructor()
+      # The default constructor method for +input+, +output+ and +error+ class (default: +:[]+)
+      # @return [Class] The Output class
+
+      # @!method default_constructor(sym_or_proc)
+      # Set the default constructor method for +input+, +output+ and +error+ class
+      #
+      # defaults to +:[]+
+      #
+      # @param sym_or_proc [Symbol,#call] The method name on the +input+,
+      #   +output+ and +error+ class or a callable which accepts the
+      #   +input+, +output+ or +error+
+      #
+      # @return [Symbol,#call]
       def default_constructor(sym_or_proc = nil)
         return @default_constructor if sym_or_proc.nil?
 
@@ -11,57 +25,24 @@ module Teckel
       end
     end
 
+    # @!visibility protected
     def initialize
-      @input_class = nil
-      @input_constructor = nil
-
-      @output_class = nil
-      @output_constructor = nil
-
-      @error_class = nil
-      @error_constructor = nil
+      @config = {}
     end
 
-    def input(klass = nil)
-      return @input_class if klass.nil?
-      raise FrozenConfigError unless @input_class.nil?
-
-      @input_class = klass
-    end
-
-    def input_constructor(sym_or_proc = nil)
-      return (@input_constructor || self.class.default_constructor) if sym_or_proc.nil?
-      raise FrozenConfigError unless @input_constructor.nil?
-
-      @input_constructor = sym_or_proc
-    end
-
-    def output(klass = nil)
-      return @output_class if klass.nil?
-      raise FrozenConfigError unless @output_class.nil?
-
-      @output_class = klass
-    end
-
-    def output_constructor(sym_or_proc = nil)
-      return (@output_constructor || self.class.default_constructor) if sym_or_proc.nil?
-      raise FrozenConfigError unless @output_constructor.nil?
-
-      @output_constructor = sym_or_proc
-    end
-
-    def error(klass = nil)
-      return @error_class if klass.nil?
-      raise FrozenConfigError unless @error_class.nil?
-
-      @error_class = klass
-    end
-
-    def error_constructor(sym_or_proc = nil)
-      return (@error_constructor || self.class.default_constructor) if sym_or_proc.nil?
-      raise FrozenConfigError unless @error_constructor.nil?
-
-      @error_constructor = sym_or_proc
+    # @!visibility protected
+    def for(key, value = nil, &block)
+      if value.nil?
+        if block
+          @config[key] ||= @config.fetch(key, &block)
+        else
+          @config[key]
+        end
+      elsif @config.key?(key)
+        raise FrozenConfigError, "Configuration #{key} is already set"
+      else
+        @config[key] = value
+      end
     end
   end
 end

--- a/lib/teckel/none.rb
+++ b/lib/teckel/none.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Teckel
+  # Simple type object for enforcing +input+, +output+ or +error+ data to be
+  # not set (or +nil+)
+  class None
+    class << self
+      # Always return nil
+      # @return nil
+      # @raise [ArgumentError] when called with any non-nil arguments
+      def [](*args)
+        raise ArgumentError, "None called with arguments" if args.any?(&:itself)
+      end
+
+      alias :new :[]
+    end
+  end
+end

--- a/lib/teckel/result.rb
+++ b/lib/teckel/result.rb
@@ -30,7 +30,7 @@ module Teckel
     # @param success [Bool] whether this is a successful result
     def initialize(value, success)
       @value = value
-      @success = success
+      @success = (!!success).freeze
     end
 
     # @!attribute [r] value

--- a/spec/chain_spec.rb
+++ b/spec/chain_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Teckel::Chain do
       include ::Teckel::Operation::Results
 
       input Types.Instance(User)
+      error none
       output input
 
       def call(usr)
@@ -76,6 +77,7 @@ RSpec.describe Teckel::Chain do
   it 'Chain errors maps all step errors' do
     expect(TeckelChainTest::Chain.errors).to eq([
       TeckelChainTest::CreateUser.error,
+      Teckel::None,
       TeckelChainTest::AddFriend.error
     ])
   end

--- a/spec/chain_spec.rb
+++ b/spec/chain_spec.rb
@@ -110,4 +110,62 @@ RSpec.describe Teckel::Chain do
       expect(result.step).to eq(TeckelChainTest::AddFriend)
     end
   end
+
+  describe "#finalize!" do
+    let(:frozen_error) do
+      # different ruby versions raise different errors
+      defined?(FrozenError) ? FrozenError : RuntimeError
+    end
+
+    it "freezes the Chain class" do
+      chain = TeckelChainTest::Chain.dup
+
+      chain.finalize!
+      expect(chain).to be_frozen
+    end
+
+    it "disallows adding new steps" do
+      chain = TeckelChainTest::Chain.dup
+
+      chain.class_eval do
+        step :other, TeckelChainTest::AddFriend
+      end
+
+      chain.finalize!
+
+      expect {
+        chain.class_eval do
+          step :yet_other, TeckelChainTest::AddFriend
+        end
+      }.to raise_error(frozen_error)
+    end
+
+    it "disallows changing around hook" do
+      chain = TeckelChainTest::Chain.dup
+      chain.class_eval do
+        around ->{}
+      end
+
+      chain2 = TeckelChainTest::Chain.dup.finalize!
+      expect {
+        chain2.class_eval do
+          around ->{}
+        end
+      }.to raise_error(frozen_error)
+    end
+
+    specify "#dup" do
+      chain = TeckelChainTest::Chain.dup
+
+      expect(chain.dup).not_to be_frozen
+      expect(chain.finalize!.dup).not_to be_frozen
+    end
+
+    specify "#clone" do
+      chain = TeckelChainTest::Chain.dup
+
+      expect(chain.clone).not_to be_frozen
+      expect(chain.finalize!.clone).to be_frozen
+    end
+  end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'support/dry_base'
+require 'support/fake_models'
+
+RSpec.describe Teckel::Config do
+  let(:sample_config) do
+    Teckel::Config.new
+  end
+
+  it "set and retrieve key" do
+    sample_config.for(:some_key, "some_value")
+    expect(sample_config.for(:some_key)).to eq("some_value")
+  end
+
+  it "allow default value via block" do
+    expect(sample_config.for(:some_key) { "default" }).to eq("default")
+    # and sets the block value
+    expect(sample_config.for(:some_key)).to eq("default")
+  end
+
+  it "raises FrozenConfigError when setting a key twice" do
+    sample_config.for(:some_key, "some_value")
+    expect { sample_config.for(:some_key, "other_value") }.to raise_error(Teckel::FrozenConfigError)
+  end
+
+  context "overwriting the default constructor" do
+    before do
+      @default_value = Teckel::Config.default_constructor
+      Teckel::Config.default_constructor(:narf)
+    end
+
+    after do
+      Teckel::Config.default_constructor(@default_value)
+    end
+
+    module TeckelConfigDefaultConstructorTest
+      class Pinky
+        def self.narf
+          "zort"
+        end
+      end
+
+      class MyOperation
+        include Teckel::Operation
+
+        input Pinky
+      end
+    end
+
+    specify do
+      expect(TeckelConfigDefaultConstructorTest::MyOperation.input_constructor).to eq(
+        TeckelConfigDefaultConstructorTest::Pinky.method(:narf)
+      )
+    end
+  end
+end

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -167,4 +167,137 @@ RSpec.describe Teckel::Operation do
       expect(TeckelOperationAnnonClassesTest::CreateUser.call(name: "Bob", age: 10)).to eq(message: "Could not save User", errors: [{ age: "underage" }])
     end
   end
+
+  context "callable constructor objects" do
+    module TeckelOperationCallableConstructorObjectsTest
+      class MyOperation
+        include ::Teckel::Operation
+
+        input User
+        input_constructor ->(data) { data[:age] *= 2; input.new(**data) }
+        output Types.Instance(User)
+        error none
+
+        def call(input)
+          input
+        end
+      end
+    end
+
+    specify do
+      result = TeckelOperationCallableConstructorObjectsTest::MyOperation.call(name: "Bob", age: 23)
+      expect(result).to be_a(User)
+      expect(result.age).to eq(46)
+    end
+  end
+
+  context "generated output" do
+    module TeckelOperationGeneratedOutputTest
+      class MyOperation
+        include ::Teckel::Operation
+
+        input none
+        output Struct.new(:some_key, keyword_init: true)
+        error none
+
+        def call(_input)
+          { some_key: "some_value" }
+        end
+      end
+    end
+
+    specify "result" do
+      result = TeckelOperationGeneratedOutputTest::MyOperation.call
+      expect(result).to be_a(Struct)
+      expect(result.some_key).to eq("some_value")
+    end
+  end
+
+  context "None in, out, err" do
+    module TeckelOperationNoneDataTest
+      class MyOperation
+        include ::Teckel::Operation
+
+        class << self
+          attr_accessor :fail_it
+          attr_accessor :fail_data
+          attr_accessor :success_it
+          attr_accessor :success_data
+        end
+
+        input none
+        output none
+        error none
+
+        def call(_input)
+          if self.class.fail_it
+            if self.class.fail_data
+              fail!(self.class.fail_data)
+            else
+              fail!
+            end
+          elsif self.class.success_it
+            if self.class.success_data
+              success!(self.class.success_data)
+            else
+              success!
+            end
+          else
+            self.class.success_data || nil
+          end
+        end
+      end
+    end
+
+    after {
+      TeckelOperationNoneDataTest::MyOperation.fail_it = nil
+      TeckelOperationNoneDataTest::MyOperation.fail_data = nil
+      TeckelOperationNoneDataTest::MyOperation.success_it = nil
+      TeckelOperationNoneDataTest::MyOperation.success_data = nil
+    }
+
+    it "raises error when called with input data" do
+      expect {
+        TeckelOperationNoneDataTest::MyOperation.call("stuff")
+      }.to raise_error(ArgumentError)
+    end
+
+    it "raises error when fail! with data" do
+      TeckelOperationNoneDataTest::MyOperation.fail_it = true
+      TeckelOperationNoneDataTest::MyOperation.fail_data = "stuff"
+      expect {
+        TeckelOperationNoneDataTest::MyOperation.call
+      }.to raise_error(ArgumentError)
+    end
+
+    it "returns nil as failure result when fail! without arguments" do
+      TeckelOperationNoneDataTest::MyOperation.fail_it = true
+      expect(TeckelOperationNoneDataTest::MyOperation.call).to be_nil
+    end
+
+    it "raises error when success! with data" do
+      TeckelOperationNoneDataTest::MyOperation.success_it = true
+      TeckelOperationNoneDataTest::MyOperation.success_data = "stuff"
+      expect {
+        TeckelOperationNoneDataTest::MyOperation.call
+      }.to raise_error(ArgumentError)
+    end
+
+    it "returns nil as success result when success! without arguments" do
+      TeckelOperationNoneDataTest::MyOperation.success_it = true
+      expect(TeckelOperationNoneDataTest::MyOperation.call).to be_nil
+    end
+
+    it "raises error when returning data" do
+      TeckelOperationNoneDataTest::MyOperation.success_it = false
+      TeckelOperationNoneDataTest::MyOperation.success_data = "stuff"
+      expect {
+        TeckelOperationNoneDataTest::MyOperation.call
+      }.to raise_error(ArgumentError)
+    end
+
+    it "returns nil as success result when returning nil" do
+      expect(TeckelOperationNoneDataTest::MyOperation.call).to be_nil
+    end
+  end
 end

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -197,7 +197,8 @@ RSpec.describe Teckel::Operation do
         include ::Teckel::Operation
 
         input none
-        output Struct.new(:some_key, keyword_init: true)
+        output Struct.new(:some_key)
+        output_constructor ->(data) { output.new(*data.values_at(*output.members)) } # ruby 2.4 way for `keyword_init: true`
         error none
 
         def call(_input)

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -168,29 +168,6 @@ RSpec.describe Teckel::Operation do
     end
   end
 
-  context "callable constructor objects" do
-    module TeckelOperationCallableConstructorObjectsTest
-      class MyOperation
-        include ::Teckel::Operation
-
-        input User
-        input_constructor ->(data) { data[:age] *= 2; input.new(**data) }
-        output Types.Instance(User)
-        error none
-
-        def call(input)
-          input
-        end
-      end
-    end
-
-    specify do
-      result = TeckelOperationCallableConstructorObjectsTest::MyOperation.call(name: "Bob", age: 23)
-      expect(result).to be_a(User)
-      expect(result.age).to eq(46)
-    end
-  end
-
   context "generated output" do
     module TeckelOperationGeneratedOutputTest
       class MyOperation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,9 @@
 require "bundler/setup"
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start do
+    add_filter %r{^/spec/}
+  end
 end
 
 require "teckel"


### PR DESCRIPTION
Enforce input, output and error declaration

- allow `None` value to indicate and enforce nil data
- refactored `Config` to hold any data, but raises on double set etc.
- moved in, out, err Operation class config to it’s Config instance