### PR TITLE
Add dependency injection for Operation and Chain

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
 --require spec_helper

--- a/lib/teckel/chain.rb
+++ b/lib/teckel/chain.rb
@@ -47,19 +47,16 @@ module Teckel
   #   end
   #
   #   class AddFriend
-  #     class << self
-  #       # Don't actually do this! It's not safe and for generating the failure sample only.
-  #       attr_accessor :fail_befriend
-  #     end
-  #
   #     include ::Teckel::Operation::Results
+  #
+  #     settings Struct.new(:fail_befriend)
   #
   #     input Types.Instance(User)
   #     output Types::Hash.schema(user: Types.Instance(User), friend: Types.Instance(User))
   #     error  Types::Hash.schema(message: Types::String)
   #
   #     def call(user)
-  #       if self.class.fail_befriend
+  #       if settings&.fail_befriend == :fail
   #         fail!(message: "Did not find a friend.")
   #       else
   #         { user: user, friend: User.new(name: "A friend", age: 42) }
@@ -80,13 +77,14 @@ module Teckel
   #   result.success[:user].is_a?(User)     #=> true
   #   result.success[:friend].is_a?(User)   #=> true
   #
-  #   AddFriend.fail_befriend = true
-  #   failure_result = MyChain.call(name: "Bob", age: 23)
+  #   failure_result = MyChain.with(befriend: :fail).call(name: "Bob", age: 23)
   #   failure_result.is_a?(Teckel::Chain::StepFailure) #=> true
   #
   #   # additional step information
   #   failure_result.step                   #=> :befriend
-  #   failure_result.operation              #=> AddFriend
+  #
+  #   ran_operation = failure_result.operation
+  #   ran_operation.is_a?(Teckel::Operation::Results::Runner) #=> true
   #
   #   # otherwise behaves just like a normal +Result+
   #   failure_result.failure?               #=> true
@@ -111,19 +109,16 @@ module Teckel
   #   end
   #
   #   class AddFriend
-  #     class << self
-  #       # Don't actually do this! It's not safe and for generating the failure sample only.
-  #       attr_accessor :fail_befriend
-  #     end
-  #
   #     include ::Teckel::Operation::Results
+  #
+  #     settings Struct.new(:fail_befriend)
   #
   #     input Types.Instance(User)
   #     output Types::Hash.schema(user: Types.Instance(User), friend: Types.Instance(User))
   #     error  Types::Hash.schema(message: Types::String)
   #
   #     def call(user)
-  #       if self.class.fail_befriend
+  #       if settings&.fail_befriend == :fail
   #         fail!(message: "Did not find a friend.")
   #       else
   #         { user: user, friend: User.new(name: "A friend", age: 42) }
@@ -158,8 +153,7 @@ module Teckel
   #     step :befriend, AddFriend
   #   end
   #
-  #   AddFriend.fail_befriend = true
-  #   failure_result = MyChain.call(name: "Bob", age: 23)
+  #   failure_result = MyChain.with(befriend: :fail).call(name: "Bob", age: 23)
   #   failure_result.is_a?(Teckel::Chain::StepFailure) #=> true
   #
   #   # triggered DB rollback
@@ -167,7 +161,9 @@ module Teckel
   #
   #   # additional step information
   #   failure_result.step                   #=> :befriend
-  #   failure_result.operation              #=> AddFriend
+  #
+  #   ran_operation = failure_result.operation
+  #   ran_operation.is_a?(Teckel::Operation::Results::Runner) #=> true
   #
   #   # otherwise behaves just like a normal +Result+
   #   failure_result.failure?               #=> true
@@ -179,6 +175,10 @@ module Teckel
         name.freeze
         operation.finalize!
         freeze
+      end
+
+      def with(settings)
+        self.class.new(name, operation.with(settings))
       end
     end
 
@@ -199,7 +199,8 @@ module Teckel
 
       # @!method operation
       #   Delegates to +step.operation+
-      #   @return [Teckel::Operation] The failed Operation class.
+      #   @return [Teckel::Operation,Class]
+      #     The failed Operation. Either the class itself or it's runner.
       def_delegator :@step, :operation
 
       # @!attribute result [R]
@@ -375,6 +376,19 @@ module Teckel
           around.call(runner, input)
         else
           runner.call(input)
+        end
+      end
+
+      # @param settings [Hash{String,Symbol => Object}] Set settings for a step by it's name
+      def with(settings)
+        set_steps = steps.map do |step|
+          settings.key?(step.name) ? step.with(settings[step.name]) : step
+        end
+        runner = self.runner.new(set_steps)
+        if around
+          ->(input) { around.call(runner, input) }
+        else
+          runner
         end
       end
 

--- a/lib/teckel/chain.rb
+++ b/lib/teckel/chain.rb
@@ -391,6 +391,7 @@ module Teckel
           runner
         end
       end
+      alias :set :with
 
       # @!visibility private
       # @return [void]

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -151,7 +151,7 @@ module Teckel
 
       # @!attribute [r] input_constructor()
       # The callable constructor to build an instance of the +input+ class.
-      # @return [Class] The Input class
+      # @return [Proc] A callable that will return an instance of the +input+ class.
 
       # @!method input_constructor(sym_or_proc)
       # Define how to build the +input+.
@@ -209,7 +209,7 @@ module Teckel
 
       # @!attribute [r] output_constructor()
       # The callable constructor to build an instance of the +output+ class.
-      # @return [Class] The Output class
+      # @return [Proc] A callable that will return an instance of +output+ class.
 
       # @!method output_constructor(sym_or_proc)
       # Define how to build the +output+.
@@ -253,7 +253,7 @@ module Teckel
 
       # @!attribute [r] error_constructor()
       # The callable constructor to build an instance of the +error+ class.
-      # @return [Class] The Error class
+      # @return [Proc] A callable that will return an instance of +error+ class.
 
       # @!method error_constructor(sym_or_proc)
       # Define how to build the +error+.
@@ -326,8 +326,8 @@ module Teckel
 
       # Invoke the Operation
       #
-      # @param input Any form of input your +input+ class can handle via the given +input_constructor+
-      # @return Either An instance of your defined +error+ class or +output+ class
+      # @param input Any form of input your {#input} class can handle via the given {#input_constructor}
+      # @return Either An instance of your defined {#error} class or {#output} class
       # @!visibility public
       def call(input = nil)
         runner.new(self).call(input)

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -395,7 +395,7 @@ module Teckel
       # it's definition, prior to running {#call}.
       #
       # @param input Any form of input your {#settings} class can handle via the given {#settings_constructor}
-      # @return [Setter]
+      # @return [Class] The configured {runner}
       # @!visibility public
       #
       # @example Inject settings for an operation call

--- a/spec/chain_around_hook_spec.rb
+++ b/spec/chain_around_hook_spec.rb
@@ -26,18 +26,16 @@ RSpec.describe Teckel::Chain do
     end
 
     class AddFriend
-      class << self
-        attr_accessor :fail_befriend
-      end
-
       include ::Teckel::Operation::Results
+
+      settings Struct.new(:fail_befriend)
 
       input Types.Instance(User)
       output Types::Hash.schema(user: Types.Instance(User), friend: Types.Instance(User))
       error  Types::Hash.schema(message: Types::String)
 
       def call(user)
-        if self.class.fail_befriend
+        if settings&.fail_befriend
           fail!(message: "Did not find a friend.")
         else
           { user: user, friend: User.new(name: "A friend", age: 42) }
@@ -78,8 +76,6 @@ RSpec.describe Teckel::Chain do
   before { TeckelChainAroundHookTest.stack.clear }
 
   context "success" do
-    before { TeckelChainAroundHookTest::AddFriend.fail_befriend = false }
-
     it "result matches" do
       result = TeckelChainAroundHookTest::Chain.call(name: "Bob", age: 23)
       expect(result.success).to include(user: kind_of(User), friend: kind_of(User))
@@ -92,10 +88,10 @@ RSpec.describe Teckel::Chain do
   end
 
   context "failure" do
-    before { TeckelChainAroundHookTest::AddFriend.fail_befriend = true }
-
     it "runs around hook" do
-      TeckelChainAroundHookTest::Chain.call(name: "Bob", age: 23)
+      TeckelChainAroundHookTest::Chain.
+        with(befriend: :fail).
+        call(name: "Bob", age: 23)
       expect(TeckelChainAroundHookTest.stack).to eq([:before])
     end
   end

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -265,86 +265,67 @@ RSpec.describe Teckel::Operation do
       class MyOperation
         include ::Teckel::Operation
 
-        class << self
-          attr_accessor :fail_it
-          attr_accessor :fail_data
-          attr_accessor :success_it
-          attr_accessor :success_data
-        end
+        settings Struct.new(:fail_it, :fail_data, :success_it, :success_data)
+        settings_constructor ->(data) { settings.new(*data.values_at(*settings.members)) }
 
         input none
         output none
         error none
 
         def call(_input)
-          if self.class.fail_it
-            if self.class.fail_data
-              fail!(self.class.fail_data)
+          if settings&.fail_it
+            if settings&.fail_data
+              fail!(settings.fail_data)
             else
               fail!
             end
-          elsif self.class.success_it
-            if self.class.success_data
-              success!(self.class.success_data)
+          elsif settings&.success_it
+            if settings&.success_data
+              success!(settings.success_data)
             else
               success!
             end
           else
-            self.class.success_data || nil
+            settings&.success_data
           end
         end
       end
     end
 
-    after {
-      TeckelOperationNoneDataTest::MyOperation.fail_it = nil
-      TeckelOperationNoneDataTest::MyOperation.fail_data = nil
-      TeckelOperationNoneDataTest::MyOperation.success_it = nil
-      TeckelOperationNoneDataTest::MyOperation.success_data = nil
-    }
+    let(:operation) { TeckelOperationNoneDataTest::MyOperation }
 
     it "raises error when called with input data" do
-      expect {
-        TeckelOperationNoneDataTest::MyOperation.call("stuff")
-      }.to raise_error(ArgumentError)
+      expect { operation.call("stuff") }.to raise_error(ArgumentError)
     end
 
     it "raises error when fail! with data" do
-      TeckelOperationNoneDataTest::MyOperation.fail_it = true
-      TeckelOperationNoneDataTest::MyOperation.fail_data = "stuff"
       expect {
-        TeckelOperationNoneDataTest::MyOperation.call
+        operation.with(fail_it: true, fail_data: "stuff").call
       }.to raise_error(ArgumentError)
     end
 
     it "returns nil as failure result when fail! without arguments" do
-      TeckelOperationNoneDataTest::MyOperation.fail_it = true
-      expect(TeckelOperationNoneDataTest::MyOperation.call).to be_nil
+      expect(operation.with(fail_it: true).call).to be_nil
     end
 
     it "raises error when success! with data" do
-      TeckelOperationNoneDataTest::MyOperation.success_it = true
-      TeckelOperationNoneDataTest::MyOperation.success_data = "stuff"
       expect {
-        TeckelOperationNoneDataTest::MyOperation.call
+        operation.with(success_it: true, success_data: "stuff").call
       }.to raise_error(ArgumentError)
     end
 
     it "returns nil as success result when success! without arguments" do
-      TeckelOperationNoneDataTest::MyOperation.success_it = true
-      expect(TeckelOperationNoneDataTest::MyOperation.call).to be_nil
+      expect(operation.with(success_it: true).call).to be_nil
     end
 
     it "raises error when returning data" do
-      TeckelOperationNoneDataTest::MyOperation.success_it = false
-      TeckelOperationNoneDataTest::MyOperation.success_data = "stuff"
       expect {
-        TeckelOperationNoneDataTest::MyOperation.call
+        operation.with(success_it: false, success_data: "stuff").call
       }.to raise_error(ArgumentError)
     end
 
     it "returns nil as success result when returning nil" do
-      expect(TeckelOperationNoneDataTest::MyOperation.call).to be_nil
+      expect(operation.call).to be_nil
     end
   end
 

--- a/spec/rb27/pattern_matching_spec.rb
+++ b/spec/rb27/pattern_matching_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Ruby 2.7 pattern matches for Result and Chain" do
     end
   end
 
-  describe "Result" do
+  describe "Operation Result" do
     context "success" do
       specify "pattern matching with keys" do
         x =
@@ -104,8 +104,13 @@ RSpec.describe "Ruby 2.7 pattern matches for Result and Chain" do
       end
 
       specify "pattern matching array" do
+        result =
+          TeckelChainPatternMatchingTest::AddFriend.
+          with(befriend: :fail).
+          call(User.new(name: "bob", age: 23))
+
         x =
-          case TeckelChainPatternMatchingTest::AddFriend.call(User.new(name: "bob", age: 23))
+          case result
           in [false, value]
             ["Failed", value]
           in [true, value]
@@ -148,9 +153,9 @@ RSpec.describe "Ruby 2.7 pattern matches for Result and Chain" do
     context "failure" do
       specify "pattern matching with keys" do
         result =
-          TeckelChainPatternMatchingTest::AddFriend.
+          TeckelChainPatternMatchingTest::Chain.
           with(befriend: :fail).
-          call(User.new(name: "bob", age: 23))
+          call(name: "bob", age: 23)
 
         x =
           case result
@@ -163,8 +168,13 @@ RSpec.describe "Ruby 2.7 pattern matches for Result and Chain" do
       end
 
       specify "pattern matching array" do
+        result =
+          TeckelChainPatternMatchingTest::Chain.
+          with(befriend: :fail).
+          call(name: "Bob", age: 23)
+
         x =
-          case TeckelChainPatternMatchingTest::Chain.call(name: "Bob", age: 23)
+          case result
           in [false, :befriend, value]
               "Failed in befriend with #{value}"
           in [true, value]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.formatter = config.files_to_run.size > 1 ? :progress : :documentation
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
This adds a `with` method (aliased to `set`) to Operation and Chain classes, allowing to inject settings into operations other than the usual input.

Note that for failed Operations which got settings set, the `StepFailure#operation` will return the operations Runner set instead of the Operation class. The Runner will include the original operation class along with the settings that where used to execute it.

fixes #6 