### PR TITLE
Add simple support for using Base classes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,6 +27,6 @@
     MyOp.call("input").to_monad do
     end
     ```
-- Check if/how to deal with inheritance 
+  This is kind of available using `.result`, which allows wrapping the operations output into anything.
 - ...
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "simplecov", require: false
+  # somehow codeclimate testreporter cannot cope with simplecov 0.18 (yet)
+  # https://github.com/codeclimate/test-reporter/issues/413
+  gem "simplecov", "< 0.18.0", require: false
 end

--- a/lib/teckel.rb
+++ b/lib/teckel.rb
@@ -11,6 +11,8 @@ module Teckel
 
   # missing important configurations (like contracts) will raise this
   class MissingConfigError < Teckel::Error; end
+
+  DEFAULT_CONSTRUCTOR = :[]
 end
 
 require_relative "teckel/config"

--- a/lib/teckel/config.rb
+++ b/lib/teckel/config.rb
@@ -2,44 +2,6 @@
 
 module Teckel
   class Config
-    class << self
-      # @!attribute [r] default_constructor()
-      # The default constructor method for +input+, +output+ and +error+ class (default: +:[]+)
-      # @return [Class] The Output class
-
-      # @!method default_constructor(sym_or_proc)
-      # Set the default constructor method for +input+, +output+ and +error+ class
-      #
-      # defaults to +:[]+
-      #
-      # @param sym_or_proc [Symbol,#call] The method name on the +input+,
-      #   +output+ and +error+ class or a callable which accepts the
-      #   +input+, +output+ or +error+
-      #
-      # @return [Symbol,#call]
-      def default_constructor(sym_or_proc = nil)
-        return @default_constructor if sym_or_proc.nil?
-
-        @default_constructor = sym_or_proc
-      end
-
-      def results!
-        @results = true
-      end
-
-      def results?
-        @results
-      end
-
-      # @!visibility private
-      def reset!
-        @default_constructor = :[]
-        @results = false
-      end
-    end
-
-    reset!
-
     # @!visibility private
     def initialize
       @config = {}

--- a/spec/chain/inheritance_spec.rb
+++ b/spec/chain/inheritance_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'support/dry_base'
+require 'support/fake_models'
+
+RSpec.describe Teckel::Chain do
+  module TeckelChainDefaultsViaBaseClass
+    LOG = [] # rubocop:disable Style/MutableConstant
+
+    class LoggingChain
+      include Teckel::Chain
+
+      around do |chain, input|
+        require 'benchmark'
+        result = nil
+        LOG << Benchmark.measure { result = chain.call(input) }
+        result
+      end
+
+      freeze
+    end
+
+    class OperationA
+      include Teckel::Operation
+
+      result!
+
+      input none
+      output Types::Integer
+      error none
+
+      def call(_)
+        rand(1000)
+      end
+
+      finalize!
+    end
+
+    class OperationB
+      include Teckel::Operation
+
+      result!
+
+      input none
+      output Types::String
+      error none
+
+      def call(_)
+        ("a".."z").to_a.sample
+      end
+
+      finalize!
+    end
+
+    class ChainA < LoggingChain
+      step :roll, OperationA
+
+      finalize!
+    end
+
+    class ChainB < LoggingChain
+      step :say, OperationB
+
+      finalize!
+    end
+
+    class ChainC < ChainB
+      finalize!
+    end
+  end
+
+  before do
+    TeckelChainDefaultsViaBaseClass::LOG.clear
+  end
+
+  let(:base_chain) { TeckelChainDefaultsViaBaseClass::LoggingChain }
+  let(:chain_a) { TeckelChainDefaultsViaBaseClass::ChainA }
+  let(:chain_b) { TeckelChainDefaultsViaBaseClass::ChainB }
+  let(:chain_c) { TeckelChainDefaultsViaBaseClass::ChainC }
+
+  it "inherits config" do
+    expect(chain_a.around)
+    expect(chain_b.around)
+
+    expect(base_chain.steps).to eq([])
+    expect(chain_a.steps.size).to eq(1)
+    expect(chain_b.steps.size).to eq(1)
+  end
+
+  it "runs chain a" do
+    expect {
+      result = chain_a.call
+      expect(result.success).to be_a(Integer)
+    }.to change {
+      TeckelChainDefaultsViaBaseClass::LOG.size
+    }.from(0).to(1)
+  end
+
+  it "runs chain b" do
+    expect {
+      result = chain_b.call
+      expect(result.success).to be_a(String)
+    }.to change {
+      TeckelChainDefaultsViaBaseClass::LOG.size
+    }.from(0).to(1)
+  end
+
+  it "inherits steps" do
+    expect {
+      result = chain_c.call
+      expect(result.success).to be_a(String)
+    }.to change {
+      TeckelChainDefaultsViaBaseClass::LOG.size
+    }.from(0).to(1)
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -23,35 +23,4 @@ RSpec.describe Teckel::Config do
     sample_config.for(:some_key, "some_value")
     expect { sample_config.for(:some_key, "other_value") }.to raise_error(Teckel::FrozenConfigError)
   end
-
-  context "overwriting the default constructor" do
-    before do
-      @default_value = Teckel::Config.default_constructor
-      Teckel::Config.default_constructor(:narf)
-    end
-
-    after do
-      Teckel::Config.default_constructor(@default_value)
-    end
-
-    module TeckelConfigDefaultConstructorTest
-      class Pinky
-        def self.narf
-          "zort"
-        end
-      end
-
-      class MyOperation
-        include Teckel::Operation
-
-        input Pinky
-      end
-    end
-
-    specify do
-      expect(TeckelConfigDefaultConstructorTest::MyOperation.input_constructor).to eq(
-        TeckelConfigDefaultConstructorTest::Pinky.method(:narf)
-      )
-    end
-  end
 end

--- a/spec/operation/inheritance_spec.rb
+++ b/spec/operation/inheritance_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe Teckel::Operation do
+  context "default settings via base class" do
+    module TeckelOperationDefaultsViaBaseClass
+      DefaultError = Struct.new(:message, :status_code)
+      Settings = Struct.new(:fail_it)
+
+      class ApplicationOperation
+        include Teckel::Operation
+
+        settings Settings
+        settings_constructor ->(data) { settings.new(*data.values_at(*settings.members)) }
+
+        error DefaultError
+        error_constructor ->(data) { error.new(*data.values_at(*error.members)) }
+
+        result!
+
+        # Freeze the base class to make sure it's inheritable configuration is not altered
+        freeze
+      end
+
+      class OperationA < ApplicationOperation
+        input Struct.new(:input_data_a)
+        output Struct.new(:output_data_a)
+
+        def call(input)
+          if settings&.fail_it
+            fail!(message: settings.fail_it, status_code: 400)
+          else
+            input.input_data_a * 2
+          end
+        end
+
+        finalize!
+      end
+
+      class OperationB < ApplicationOperation
+        input Struct.new(:input_data_b)
+        output Struct.new(:output_data_b)
+
+        def call(input)
+          if settings&.fail_it
+            fail!(message: settings.fail_it, status_code: 500)
+          else
+            input.input_data_b * 4
+          end
+        end
+
+        finalize!
+      end
+    end
+
+    let(:operation_a) { TeckelOperationDefaultsViaBaseClass::OperationA }
+    let(:operation_b) { TeckelOperationDefaultsViaBaseClass::OperationB }
+
+    it "inherits config" do
+      expect(operation_a.result).to eq(Teckel::Operation::Result)
+      expect(operation_a.settings).to eq(TeckelOperationDefaultsViaBaseClass::Settings)
+
+      expect(operation_b.result).to eq(Teckel::Operation::Result)
+      expect(operation_b.settings).to eq(TeckelOperationDefaultsViaBaseClass::Settings)
+    end
+
+    context "operation_a" do
+      it "can run" do
+        result = operation_a.call(10)
+        expect(result.success.to_h).to eq(output_data_a: 20)
+      end
+
+      it "can fail" do
+        result = operation_a.with(fail_it: "D'oh!").call(10)
+        expect(result.failure.to_h).to eq(
+          message: "D'oh!", status_code: 400
+        )
+      end
+    end
+
+    context "operation_b" do
+      it "can run" do
+        result = operation_b.call(10)
+        expect(result.success.to_h).to eq(output_data_b: 40)
+      end
+
+      it "can fail" do
+        result = operation_b.with(fail_it: "D'oh!").call(10)
+        expect(result.failure.to_h).to eq(
+          message: "D'oh!", status_code: 500
+        )
+      end
+    end
+  end
+end

--- a/spec/operation/results_spec.rb
+++ b/spec/operation/results_spec.rb
@@ -114,44 +114,4 @@ RSpec.describe Teckel::Operation do
       expect(CreateUserOverwritingResult.result_constructor).to eq(CreateUserOverwritingResult::Result.method(:[]))
     end
   end
-
-  context "using results by default" do
-    before { Teckel::Config.results! }
-    after  { Teckel::Config.reset! }
-
-    let(:operation) do
-      Class.new do
-        include Teckel::Operation
-
-        # result! # < this should be done automatically
-
-        input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer)
-        output Types.Instance(User)
-        error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
-
-        def call(input)
-          user = User.new(name: input[:name], age: input[:age])
-          if user.save
-            user
-          else
-            fail!(message: "Could not save User", errors: user.errors)
-          end
-        end
-      end
-    end
-
-    specify "output" do
-      result = operation.call(name: "Bob", age: 23)
-      expect(result).to be_a(Teckel::Result)
-      expect(result).to be_successful
-      expect(result.success).to be_a(User)
-    end
-
-    specify "errors" do
-      result = operation.call(name: "Bob", age: 10)
-      expect(result).to be_a(Teckel::Result)
-      expect(result).to be_failure
-      expect(result.failure).to eq(message: "Could not save User", errors: [{ age: "underage" }])
-    end
-  end
 end


### PR DESCRIPTION
…  for application specific common use cases.

This removes the `Teckel::Config::default_constructor` and `Teckel::Config.results!` global settings in favour of parent classes.

Currently, Chains and Operations will inherit all the configurations of the parent class.
That includes steps for Chains, which might or might not be useful.
Since configurations can only be set once, a child class *cannot* overwrite a parents config (eg: `input` for Operations or `around` for Chains)