### PR TITLE
Don't freeze Operation or Classes on `finalize!`

### DIFF
--- a/lib/teckel/chain.rb
+++ b/lib/teckel/chain.rb
@@ -189,15 +189,6 @@ module Teckel
         nil
       end
 
-      # Prevents further modifications to this Class and it's configuration
-      # @return [self] Frozen self
-      # @!visibility public
-      def freeze
-        steps.freeze
-        @config.freeze
-        super
-      end
-
       # Disallow any further changes to this Chain.
       # @note This also calls +finalize!+ on all Operations defined as steps.
       #
@@ -205,7 +196,9 @@ module Teckel
       # @!visibility public
       def finalize!
         define!
-        freeze
+        steps.freeze
+        @config.freeze
+        self
       end
 
       # Produces a shallow copy of this chain.

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -415,14 +415,6 @@ module Teckel
         nil
       end
 
-      # Prevents further modifications to this Class and it's configuration
-      # @return [self] Frozen self
-      # @!visibility public
-      def freeze
-        @config.freeze
-        super
-      end
-
       # Disallow any further changes to this Operation.
       # Make sure all configurations are set.
       #
@@ -431,7 +423,8 @@ module Teckel
       # @!visibility public
       def finalize!
         define!
-        freeze
+        @config.freeze
+        self
       end
 
       # Produces a shallow copy of this operation and all it's configuration.


### PR DESCRIPTION
The underlaying config objects will still be frozen.
This is allows to mock out Operation and Chain calls for example.