### PR TITLE
Move operation and chain config dsl methods into own module

### DIFF
--- a/lib/teckel/chain.rb
+++ b/lib/teckel/chain.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'chain/config'
 require_relative 'chain/step'
 require_relative 'chain/result'
 require_relative 'chain/runner'
@@ -37,122 +38,6 @@ module Teckel
         end
       end
 
-      # Declare a {Operation} as a named step
-      #
-      # @param name [String,Symbol] The name of the operation.
-      #   This name is used in an error case to let you know which step failed.
-      # @param operation [Operation] The operation to call, which
-      #   must return a {Teckel::Result} object.
-      def step(name, operation)
-        steps << Step.new(name, operation)
-      end
-
-      # Get the list of defined steps
-      #
-      # @return [<Step>]
-      def steps
-        @config.for(:steps) { [] }
-      end
-
-      # Set or get the optional around hook.
-      # A Hook might be given as a block or anything callable. The execution of
-      # the chain is yielded to this hook. The first argument being the callable
-      # chain ({Runner}) and the second argument the +input+ data. The hook also
-      # needs to return the result.
-      #
-      # @param callable [Proc,{#call}] The hook to pass chain execution control to. (nil)
-      #
-      # @return [Proc,{#call}] The configured hook
-      #
-      # @example Around hook with block
-      #   OUTPUTS = []
-      #
-      #   class Echo
-      #     include ::Teckel::Operation
-      #     result!
-      #
-      #     input Hash
-      #     output input
-      #
-      #     def call(hsh)
-      #       hsh
-      #     end
-      #   end
-      #
-      #   class MyChain
-      #     include Teckel::Chain
-      #
-      #     around do |chain, input|
-      #       OUTPUTS << "before start"
-      #       result = chain.call(input)
-      #       OUTPUTS << "after start"
-      #       result
-      #     end
-      #
-      #     step :noop, Echo
-      #   end
-      #
-      #   result = MyChain.call(some: 'test')
-      #   OUTPUTS #=> ["before start", "after start"]
-      #   result.success #=> { some: "test" }
-      def around(callable = nil, &block)
-        @config.for(:around, callable || block)
-      end
-
-      # @!attribute [r] runner()
-      # @return [Class] The Runner class
-      # @!visibility protected
-
-      # Overwrite the default runner
-      # @param klass [Class] A class like the {Runner}
-      # @!visibility protected
-      def runner(klass = nil)
-        @config.for(:runner, klass) { Runner }
-      end
-
-      # @overload result()
-      #   Get the configured result object class wrapping {.error} or {.output}.
-      #   @return [Class] The +result+ class, or {Teckel::Chain::Result} as default
-      #
-      # @overload result(klass)
-      #   Set the result object class wrapping {.error} or {.output}.
-      #   @param klass [Class] The +result+ class
-      #   @return [Class] The +result+ class configured
-      def result(klass = nil)
-        @config.for(:result, klass) { const_defined?(:Result, false) ? self::Result : Teckel::Chain::Result }
-      end
-
-      # @overload result_constructor()
-      #   The callable constructor to build an instance of the +result+ class.
-      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
-      #   @return [Proc] A callable that will return an instance of +result+ class.
-      #
-      # @overload result_constructor(sym_or_proc)
-      #  Define how to build the +result+.
-      #  @param  sym_or_proc [Symbol, #call]
-      #    - Either a +Symbol+ representing the _public_ method to call on the +result+ class.
-      #    - Or anything that response to +#call+ (like a +Proc+).
-      #  @return [#call] The callable constructor
-      #
-      #  @example
-      #    class MyOperation
-      #      include Teckel::Operation
-      #
-      #      class Result < Teckel::Operation::Result
-      #        def initialize(value, success, step, options = {}); end
-      #      end
-      #
-      #      # If you need more control over how to build a new +Settings+ instance
-      #      result_constructor ->(value, success, step) { result.new(value, success, step, {foo: :bar}) }
-      #    end
-      def result_constructor(sym_or_proc = nil)
-        constructor = build_counstructor(result, sym_or_proc) unless sym_or_proc.nil?
-
-        @config.for(:result_constructor, constructor) {
-          build_counstructor(result, Teckel::DEFAULT_CONSTRUCTOR)
-        } || raise(MissingConfigError, "Missing result_constructor config for #{self}")
-      end
-
       # The primary interface to call the chain with the given input.
       #
       # @param input Any form of input the first steps +input+ class can handle
@@ -178,81 +63,10 @@ module Teckel
         end
       end
       alias :set :with
-
-      # @!visibility private
-      # @return [void]
-      def define!
-        raise MissingConfigError, "Cannot define Chain with no steps" if steps.empty?
-
-        %i[around runner result result_constructor].each { |e| public_send(e) }
-        steps.each(&:finalize!)
-        nil
-      end
-
-      # Disallow any further changes to this Chain.
-      # @note This also calls +finalize!+ on all Operations defined as steps.
-      #
-      # @return [self] Frozen self
-      # @!visibility public
-      def finalize!
-        define!
-        steps.freeze
-        @config.freeze
-        self
-      end
-
-      # Produces a shallow copy of this chain.
-      # It's {around}, {runner} and {steps} will get +dup+'ed
-      #
-      # @return [self]
-      # @!visibility public
-      def dup
-        dup_config(super)
-      end
-
-      # Produces a clone of this chain.
-      # It's {around}, {runner} and {steps} will get +dup+'ed
-      #
-      # @return [self]
-      # @!visibility public
-      def clone
-        if frozen?
-          super
-        else
-          dup_config(super)
-        end
-      end
-
-      # @!visibility private
-      def inherited(subclass)
-        dup_config(subclass)
-      end
-
-      # @!visibility private
-      def self.extended(base)
-        base.instance_variable_set(:@config, Config.new)
-      end
-
-      private
-
-      def dup_config(other_class)
-        new_config = @config.dup
-        new_config.replace(:steps) { steps.dup }
-
-        other_class.instance_variable_set(:@config, new_config)
-        other_class
-      end
-
-      def build_counstructor(on, sym_or_proc)
-        if sym_or_proc.is_a?(Symbol) && on.respond_to?(sym_or_proc)
-          on.public_method(sym_or_proc)
-        elsif sym_or_proc.respond_to?(:call)
-          sym_or_proc
-        end
-      end
     end
 
     def self.included(receiver)
+      receiver.extend Config
       receiver.extend ClassMethods
     end
   end

--- a/lib/teckel/chain/config.rb
+++ b/lib/teckel/chain/config.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+module Teckel
+  module Chain
+    module Config
+      # Declare a {Operation} as a named step
+      #
+      # @param name [String,Symbol] The name of the operation.
+      #   This name is used in an error case to let you know which step failed.
+      # @param operation [Operation] The operation to call, which
+      #   must return a {Teckel::Result} object.
+      def step(name, operation)
+        steps << Step.new(name, operation)
+      end
+
+      # Get the list of defined steps
+      #
+      # @return [<Step>]
+      def steps
+        @config.for(:steps) { [] }
+      end
+
+      # Set or get the optional around hook.
+      # A Hook might be given as a block or anything callable. The execution of
+      # the chain is yielded to this hook. The first argument being the callable
+      # chain ({Runner}) and the second argument the +input+ data. The hook also
+      # needs to return the result.
+      #
+      # @param callable [Proc,{#call}] The hook to pass chain execution control to. (nil)
+      #
+      # @return [Proc,{#call}] The configured hook
+      #
+      # @example Around hook with block
+      #   OUTPUTS = []
+      #
+      #   class Echo
+      #     include ::Teckel::Operation
+      #     result!
+      #
+      #     input Hash
+      #     output input
+      #
+      #     def call(hsh)
+      #       hsh
+      #     end
+      #   end
+      #
+      #   class MyChain
+      #     include Teckel::Chain
+      #
+      #     around do |chain, input|
+      #       OUTPUTS << "before start"
+      #       result = chain.call(input)
+      #       OUTPUTS << "after start"
+      #       result
+      #     end
+      #
+      #     step :noop, Echo
+      #   end
+      #
+      #   result = MyChain.call(some: 'test')
+      #   OUTPUTS #=> ["before start", "after start"]
+      #   result.success #=> { some: "test" }
+      def around(callable = nil, &block)
+        @config.for(:around, callable || block)
+      end
+
+      # @!attribute [r] runner()
+      # @return [Class] The Runner class
+      # @!visibility protected
+
+      # Overwrite the default runner
+      # @param klass [Class] A class like the {Runner}
+      # @!visibility protected
+      def runner(klass = nil)
+        @config.for(:runner, klass) { Runner }
+      end
+
+      # @overload result()
+      #   Get the configured result object class wrapping {.error} or {.output}.
+      #   @return [Class] The +result+ class, or {Teckel::Chain::Result} as default
+      #
+      # @overload result(klass)
+      #   Set the result object class wrapping {.error} or {.output}.
+      #   @param klass [Class] The +result+ class
+      #   @return [Class] The +result+ class configured
+      def result(klass = nil)
+        @config.for(:result, klass) { const_defined?(:Result, false) ? self::Result : Teckel::Chain::Result }
+      end
+
+      # @overload result_constructor()
+      #   The callable constructor to build an instance of the +result+ class.
+      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
+      #   @return [Proc] A callable that will return an instance of +result+ class.
+      #
+      # @overload result_constructor(sym_or_proc)
+      #  Define how to build the +result+.
+      #  @param  sym_or_proc [Symbol, #call]
+      #    - Either a +Symbol+ representing the _public_ method to call on the +result+ class.
+      #    - Or anything that response to +#call+ (like a +Proc+).
+      #  @return [#call] The callable constructor
+      #
+      #  @example
+      #    class MyOperation
+      #      include Teckel::Operation
+      #
+      #      class Result < Teckel::Operation::Result
+      #        def initialize(value, success, step, options = {}); end
+      #      end
+      #
+      #      # If you need more control over how to build a new +Settings+ instance
+      #      result_constructor ->(value, success, step) { result.new(value, success, step, {foo: :bar}) }
+      #    end
+      def result_constructor(sym_or_proc = nil)
+        constructor = build_counstructor(result, sym_or_proc) unless sym_or_proc.nil?
+
+        @config.for(:result_constructor, constructor) {
+          build_counstructor(result, Teckel::DEFAULT_CONSTRUCTOR)
+        } || raise(MissingConfigError, "Missing result_constructor config for #{self}")
+      end
+
+      # @!visibility private
+      # @return [void]
+      def define!
+        raise MissingConfigError, "Cannot define Chain with no steps" if steps.empty?
+
+        %i[around runner result result_constructor].each { |e| public_send(e) }
+        steps.each(&:finalize!)
+        nil
+      end
+
+      # Disallow any further changes to this Chain.
+      # @note This also calls +finalize!+ on all Operations defined as steps.
+      #
+      # @return [self] Frozen self
+      # @!visibility public
+      def finalize!
+        define!
+        steps.freeze
+        @config.freeze
+        self
+      end
+
+      # Produces a shallow copy of this chain.
+      # It's {around}, {runner} and {steps} will get +dup+'ed
+      #
+      # @return [self]
+      # @!visibility public
+      def dup
+        dup_config(super)
+      end
+
+      # Produces a clone of this chain.
+      # It's {around}, {runner} and {steps} will get +dup+'ed
+      #
+      # @return [self]
+      # @!visibility public
+      def clone
+        if frozen?
+          super
+        else
+          dup_config(super)
+        end
+      end
+
+      # @!visibility private
+      def inherited(subclass)
+        dup_config(subclass)
+      end
+
+      # @!visibility private
+      def self.extended(base)
+        base.instance_variable_set(:@config, Teckel::Config.new)
+      end
+
+      private
+
+      def dup_config(other_class)
+        new_config = @config.dup
+        new_config.replace(:steps) { steps.dup }
+
+        other_class.instance_variable_set(:@config, new_config)
+        other_class
+      end
+
+      def build_counstructor(on, sym_or_proc)
+        if sym_or_proc.is_a?(Symbol) && on.respond_to?(sym_or_proc)
+          on.public_method(sym_or_proc)
+        elsif sym_or_proc.respond_to?(:call)
+          sym_or_proc
+        end
+      end
+    end
+  end
+end

--- a/lib/teckel/chain/config.rb
+++ b/lib/teckel/chain/config.rb
@@ -119,12 +119,14 @@ module Teckel
         } || raise(MissingConfigError, "Missing result_constructor config for #{self}")
       end
 
+      REQUIRED_CONFIGS = %i[around runner result result_constructor].freeze
+
       # @!visibility private
       # @return [void]
       def define!
         raise MissingConfigError, "Cannot define Chain with no steps" if steps.empty?
 
-        %i[around runner result result_constructor].each { |e| public_send(e) }
+        REQUIRED_CONFIGS.each { |e| public_send(e) }
         steps.each(&:finalize!)
         nil
       end

--- a/lib/teckel/chain/runner.rb
+++ b/lib/teckel/chain/runner.rb
@@ -36,13 +36,19 @@ module Teckel
       end
 
       def steps
-        if settings == UNDEFINED
-          chain.steps
-        else
-          Enumerator.new do |yielder|
-            chain.steps.each do |step|
-              yielder << (settings.key?(step.name) ? step.with(settings[step.name]) : step)
-            end
+        settings == UNDEFINED ? chain.steps : steps_with_settings
+      end
+
+      private
+
+      def step_with_settings(step)
+        settings.key?(step.name) ? step.with(settings[step.name]) : step
+      end
+
+      def steps_with_settings
+        Enumerator.new do |yielder|
+          chain.steps.each do |step|
+            yielder << step_with_settings(step)
           end
         end
       end

--- a/lib/teckel/config.rb
+++ b/lib/teckel/config.rb
@@ -19,11 +19,7 @@ module Teckel
     # @!visibility private
     def for(key, value = nil, &block)
       if value.nil?
-        if block
-          @config[key] ||= @config.fetch(key, &block)
-        else
-          @config[key]
-        end
+        get_or_set(key, &block)
       elsif @config.key?(key)
         raise FrozenConfigError, "Configuration #{key} is already set"
       else
@@ -46,6 +42,16 @@ module Teckel
     def dup
       super.tap do |copy|
         copy.instance_variable_set(:@config, @config.dup)
+      end
+    end
+
+    private
+
+    def get_or_set(key, &block)
+      if block
+        @config[key] ||= @config.fetch(key, &block)
+      else
+        @config[key]
       end
     end
   end

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "operation/config"
 require_relative "operation/result"
 require_relative "operation/runner"
 
@@ -56,302 +57,6 @@ module Teckel
   # @!visibility public
   module Operation
     module ClassMethods
-      # @!group Contacts definition
-
-      # @overload input()
-      #   Get the configured class wrapping the input data structure.
-      #   @return [Class] The +input+ class
-      # @overload input(klass)
-      #   Set the class wrapping the input data structure.
-      #   @param  klass [Class] The +input+ class
-      #   @return [Class] The +input+ class
-      def input(klass = nil)
-        @config.for(:input, klass) { self::Input if const_defined?(:Input) } ||
-          raise(Teckel::MissingConfigError, "Missing input config for #{self}")
-      end
-
-      # @overload input_constructor()
-      #   The callable constructor to build an instance of the +input+ class.
-      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
-      #   @return [Proc] A callable that will return an instance of the +input+ class.
-      #
-      # @overload input_constructor(sym_or_proc)
-      #   Define how to build the +input+.
-      #   @param  sym_or_proc [Symbol, #call]
-      #     - Either a +Symbol+ representing the _public_ method to call on the +input+ class.
-      #     - Or anything that response to +#call+ (like a +Proc+).
-      #   @return [#call] The callable constructor
-      #
-      #   @example simple symbol to method constructor
-      #     class MyOperation
-      #       include Teckel::Operation
-      #
-      #       class Input
-      #         def initialize(name:, age:); end
-      #       end
-      #
-      #       # If you need more control over how to build a new +Input+ instance
-      #       # MyOperation.call(name: "Bob", age: 23) # -> Input.new(name: "Bob", age: 23)
-      #       input_constructor :new
-      #     end
-      #
-      #     MyOperation.input_constructor.is_a?(Method) #=> true
-      #
-      #   @example Custom Proc constructor
-      #     class MyOperation
-      #       include Teckel::Operation
-      #
-      #       class Input
-      #         def initialize(*args, **opts); end
-      #       end
-      #
-      #       # If you need more control over how to build a new +Input+ instance
-      #       # MyOperation.call("foo", opt: "bar") # -> Input.new(name: "foo", opt: "bar")
-      #       input_constructor ->(name, options) { Input.new(name: name, **options) }
-      #     end
-      #
-      #     MyOperation.input_constructor.is_a?(Proc) #=> true
-      def input_constructor(sym_or_proc = nil)
-        get_set_counstructor(:input_constructor, input, sym_or_proc) ||
-          raise(MissingConfigError, "Missing input_constructor config for #{self}")
-      end
-
-      # @overload output()
-      #  Get the configured class wrapping the output data structure.
-      #  Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
-      #  @return [Class] The +output+ class
-      #
-      # @overload output(klass)
-      #   Set the class wrapping the output data structure.
-      #   @param  klass [Class] The +output+ class
-      #   @return [Class] The +output+ class
-      def output(klass = nil)
-        @config.for(:output, klass) { self::Output if const_defined?(:Output) } ||
-          raise(Teckel::MissingConfigError, "Missing output config for #{self}")
-      end
-
-      # @overload output_constructor()
-      #  The callable constructor to build an instance of the +output+ class.
-      #  Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
-      #  @return [Proc] A callable that will return an instance of +output+ class.
-      #
-      # @overload output_constructor(sym_or_proc)
-      #   Define how to build the +output+.
-      #   @param sym_or_proc [Symbol, #call]
-      #     - Either a +Symbol+ representing the _public_ method to call on the +output+ class.
-      #     - Or anything that response to +#call+ (like a +Proc+).
-      #   @return [#call] The callable constructor
-      #
-      #   @example
-      #     class MyOperation
-      #       include Teckel::Operation
-      #
-      #       class Output
-      #         def initialize(*args, **opts); end
-      #       end
-      #
-      #       # MyOperation.call("foo", "bar") # -> Output.new("foo", "bar")
-      #       output_constructor :new
-      #
-      #       # If you need more control over how to build a new +Output+ instance
-      #       # MyOperation.call("foo", opt: "bar") # -> Output.new(name: "foo", opt: "bar")
-      #       output_constructor ->(name, options) { Output.new(name: name, **options) }
-      #     end
-      def output_constructor(sym_or_proc = nil)
-        get_set_counstructor(:output_constructor, output, sym_or_proc) ||
-          raise(MissingConfigError, "Missing output_constructor config for #{self}")
-      end
-
-      # @overload error()
-      #   Get the configured class wrapping the error data structure.
-      #   @return [Class] The +error+ class
-      #
-      # @overload error(klass)
-      #   Set the class wrapping the error data structure.
-      #   @param klass [Class] The +error+ class
-      #   @return [Class,nil] The +error+ class or +nil+ if it does not error
-      def error(klass = nil)
-        @config.for(:error, klass) { self::Error if const_defined?(:Error) } ||
-          raise(Teckel::MissingConfigError, "Missing error config for #{self}")
-      end
-
-      # @overload error_constructor()
-      #   The callable constructor to build an instance of the +error+ class.
-      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
-      #   @return [Proc] A callable that will return an instance of +error+ class.
-      #
-      # @overload error_constructor(sym_or_proc)
-      #   Define how to build the +error+.
-      #   @param sym_or_proc [Symbol, #call]
-      #     - Either a +Symbol+ representing the _public_ method to call on the +error+ class.
-      #     - Or anything that response to +#call+ (like a +Proc+).
-      #   @return [#call] The callable constructor
-      #
-      #   @example
-      #     class MyOperation
-      #       include Teckel::Operation
-      #
-      #       class Error
-      #         def initialize(*args, **opts); end
-      #       end
-      #
-      #       # MyOperation.call("foo", "bar") # -> Error.new("foo", "bar")
-      #       error_constructor :new
-      #
-      #       # If you need more control over how to build a new +Error+ instance
-      #       # MyOperation.call("foo", opt: "bar") # -> Error.new(name: "foo", opt: "bar")
-      #       error_constructor ->(name, options) { Error.new(name: name, **options) }
-      #     end
-      def error_constructor(sym_or_proc = nil)
-        get_set_counstructor(:error_constructor, error, sym_or_proc) ||
-          raise(MissingConfigError, "Missing error_constructor config for #{self}")
-      end
-
-      # @!endgroup
-
-      # @overload settings()
-      #  Get the configured class wrapping the settings data structure.
-      #  @return [Class] The +settings+ class, or {Teckel::Contracts::None} as default
-      #
-      # @overload settings(klass)
-      #   Set the class wrapping the settings data structure.
-      #   @param klass [Class] The +settings+ class
-      #   @return [Class] The +settings+ class configured
-      def settings(klass = nil)
-        @config.for(:settings, klass) { const_defined?(:Settings) ? self::Settings : none }
-      end
-
-      # @overload settings_constructor()
-      #   The callable constructor to build an instance of the +settings+ class.
-      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
-      #   @return [Proc] A callable that will return an instance of +settings+ class.
-      #
-      # @overload settings_constructor(sym_or_proc)
-      #  Define how to build the +settings+.
-      #  @param  sym_or_proc [Symbol, #call]
-      #    - Either a +Symbol+ representing the _public_ method to call on the +settings+ class.
-      #    - Or anything that response to +#call+ (like a +Proc+).
-      #  @return [#call] The callable constructor
-      #
-      #  @example
-      #    class MyOperation
-      #      include Teckel::Operation
-      #
-      #      class Settings
-      #        def initialize(*args); end
-      #      end
-      #
-      #      # MyOperation.with("foo", "bar") # -> Settings.new("foo", "bar")
-      #      settings_constructor :new
-      #    end
-      def settings_constructor(sym_or_proc = nil)
-        get_set_counstructor(:settings_constructor, settings, sym_or_proc) ||
-          raise(MissingConfigError, "Missing settings_constructor config for #{self}")
-      end
-
-      # @overload runner()
-      #   @return [Class] The Runner class
-      #   @!visibility protected
-      #
-      # @overload runner(klass)
-      #   Overwrite the default runner
-      #   @param klass [Class] A class like the {Runner}
-      #   @!visibility protected
-      def runner(klass = nil)
-        @config.for(:runner, klass) { Teckel::Operation::Runner }
-      end
-
-      # @overload result()
-      #   Get the configured result object class wrapping {error} or {output}.
-      #   The {ValueResult} default will act as a pass-through and does. Any error
-      #   or output will just returned as-is.
-      #   @return [Class] The +result+ class, or {ValueResult} as default
-      #
-      # @overload result(klass)
-      #   Set the result object class wrapping {error} or {output}.
-      #   @param klass [Class] The +result+ class
-      #   @return [Class] The +result+ class configured
-      def result(klass = nil)
-        @config.for(:result, klass) { const_defined?(:Result, false) ? self::Result : ValueResult }
-      end
-
-      # @overload result_constructor()
-      #   The callable constructor to build an instance of the +result+ class.
-      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
-      #   @return [Proc] A callable that will return an instance of +result+ class.
-      #
-      # @overload result_constructor(sym_or_proc)
-      #  Define how to build the +result+.
-      #  @param  sym_or_proc [Symbol, #call]
-      #    - Either a +Symbol+ representing the _public_ method to call on the +result+ class.
-      #    - Or anything that response to +#call+ (like a +Proc+).
-      #  @return [#call] The callable constructor
-      #
-      #  @example
-      #    class MyOperation
-      #      include Teckel::Operation
-      #
-      #      class Result
-      #        include Teckel::Result
-      #        def initialize(value, success, opts = {}); end
-      #      end
-      #
-      #      # If you need more control over how to build a new +Settings+ instance
-      #      result_constructor ->(value, success) { result.new(value, success, {foo: :bar}) }
-      #    end
-      def result_constructor(sym_or_proc = nil)
-        get_set_counstructor(:result_constructor, result, sym_or_proc) ||
-          raise(MissingConfigError, "Missing result_constructor config for #{self}")
-      end
-
-      # @!group Shortcuts
-
-      # Shortcut to use {Teckel::Operation::Result} as a result object,
-      # wrapping any {error} or {output}.
-      #
-      # @!visibility protected
-      # @note Don't use in conjunction with {result} or {result_constructor}
-      # @return [nil]
-      def result!
-        @config.for(:result, Teckel::Operation::Result)
-        @config.for(:result_constructor, Teckel::Operation::Result.method(:new))
-        nil
-      end
-
-      # Convenience method for setting {#input}, {#output} or {#error} to the
-      # {Teckel::Contracts::None} value.
-      # @return [Object] The {Teckel::Contracts::None} class.
-      #
-      # @example Enforcing nil input, output or error
-      #   class MyOperation
-      #     include Teckel::Operation
-      #
-      #     input none
-      #
-      #     # same as
-      #     output Teckel::Contracts::None
-      #
-      #     error none
-      #
-      #     def call(_) # you still need to take than +nil+ input when using `input none`
-      #       # when using `error none`:
-      #       # `fail!` works, but `fail!("data")` raises an error
-      #
-      #       # when using `output none`:
-      #       # `success!` works, but `success!("data")` raises an error
-      #       # same thing when using simple return values as success:
-      #       # take care to not return anything
-      #       nil
-      #     end
-      #   end
-      #
-      #   MyOperation.call #=> nil
-      def none
-        Teckel::Contracts::None
-      end
-
-      # @endgroup
-
       # Invoke the Operation
       #
       # @param input Any form of input your {#input} class can handle via the given {#input_constructor}
@@ -401,85 +106,36 @@ module Teckel
       end
       alias :set :with
 
-      # @!visibility private
-      # @return [void]
-      def define!
-        %i[
-          input input_constructor
-          output output_constructor
-          error error_constructor
-          settings settings_constructor
-          result result_constructor
-          runner
-        ].each { |e| public_send(e) }
-        nil
-      end
-
-      # Disallow any further changes to this Operation.
-      # Make sure all configurations are set.
+      # Convenience method for setting {#input}, {#output} or {#error} to the
+      # {Teckel::Contracts::None} value.
+      # @return [Object] The {Teckel::Contracts::None} class.
       #
-      # @raise [MissingConfigError]
-      # @return [self] Frozen self
-      # @!visibility public
-      def finalize!
-        define!
-        @config.freeze
-        self
-      end
-
-      # Produces a shallow copy of this operation and all it's configuration.
+      # @example Enforcing nil input, output or error
+      #   class MyOperation
+      #     include Teckel::Operation
       #
-      # @return [self]
-      # @!visibility public
-      def dup
-        super.tap do |copy|
-          copy.instance_variable_set(:@config, @config.dup)
-        end
-      end
-
-      # Produces a clone of this operation and all it's configuration
+      #     input none
       #
-      # @return [self]
-      # @!visibility public
-      def clone
-        if frozen?
-          super
-        else
-          super.tap do |copy|
-            copy.instance_variable_set(:@config, @config.dup)
-          end
-        end
-      end
-
-      # @!visibility private
-      def inherited(subclass)
-        subclass.instance_variable_set(:@config, @config.dup)
-      end
-
-      # @!visibility private
-      def self.extended(base)
-        base.instance_exec do
-          @config = Config.new
-          attr_accessor :settings
-        end
-      end
-
-      private
-
-      def get_set_counstructor(name, on, sym_or_proc)
-        constructor = build_counstructor(on, sym_or_proc) unless sym_or_proc.nil?
-
-        @config.for(name, constructor) {
-          build_counstructor(on, Teckel::DEFAULT_CONSTRUCTOR)
-        }
-      end
-
-      def build_counstructor(on, sym_or_proc)
-        if sym_or_proc.is_a?(Symbol) && on.respond_to?(sym_or_proc)
-          on.public_method(sym_or_proc)
-        elsif sym_or_proc.respond_to?(:call)
-          sym_or_proc
-        end
+      #     # same as
+      #     output Teckel::Contracts::None
+      #
+      #     error none
+      #
+      #     def call(_) # you still need to take than +nil+ input when using `input none`
+      #       # when using `error none`:
+      #       # `fail!` works, but `fail!("data")` raises an error
+      #
+      #       # when using `output none`:
+      #       # `success!` works, but `success!("data")` raises an error
+      #       # same thing when using simple return values as success:
+      #       # take care to not return anything
+      #       nil
+      #     end
+      #   end
+      #
+      #   MyOperation.call #=> nil
+      def none
+        Teckel::Contracts::None
       end
     end
 
@@ -508,6 +164,7 @@ module Teckel
     end
 
     def self.included(receiver)
+      receiver.extend         Config
       receiver.extend         ClassMethods
       receiver.send :include, InstanceMethods
     end

--- a/lib/teckel/operation/config.rb
+++ b/lib/teckel/operation/config.rb
@@ -264,16 +264,19 @@ module Teckel
       end
 
       # @!visibility private
+      REQUIRED_CONFIGS = %i[
+        input input_constructor
+        output output_constructor
+        error error_constructor
+        settings settings_constructor
+        result result_constructor
+        runner
+      ].freeze
+
+      # @!visibility private
       # @return [void]
       def define!
-        %i[
-          input input_constructor
-          output output_constructor
-          error error_constructor
-          settings settings_constructor
-          result result_constructor
-          runner
-        ].each { |e| public_send(e) }
+        REQUIRED_CONFIGS.each { |e| public_send(e) }
         nil
       end
 

--- a/lib/teckel/operation/config.rb
+++ b/lib/teckel/operation/config.rb
@@ -1,0 +1,348 @@
+# frozen_string_literal: true
+
+module Teckel
+  module Operation
+    module Config
+      # @overload input()
+      #   Get the configured class wrapping the input data structure.
+      #   @return [Class] The +input+ class
+      # @overload input(klass)
+      #   Set the class wrapping the input data structure.
+      #   @param  klass [Class] The +input+ class
+      #   @return [Class] The +input+ class
+      def input(klass = nil)
+        @config.for(:input, klass) { self::Input if const_defined?(:Input) } ||
+          raise(Teckel::MissingConfigError, "Missing input config for #{self}")
+      end
+
+      # @overload input_constructor()
+      #   The callable constructor to build an instance of the +input+ class.
+      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
+      #   @return [Proc] A callable that will return an instance of the +input+ class.
+      #
+      # @overload input_constructor(sym_or_proc)
+      #   Define how to build the +input+.
+      #   @param  sym_or_proc [Symbol, #call]
+      #     - Either a +Symbol+ representing the _public_ method to call on the +input+ class.
+      #     - Or anything that response to +#call+ (like a +Proc+).
+      #   @return [#call] The callable constructor
+      #
+      #   @example simple symbol to method constructor
+      #     class MyOperation
+      #       include Teckel::Operation
+      #
+      #       class Input
+      #         def initialize(name:, age:); end
+      #       end
+      #
+      #       # If you need more control over how to build a new +Input+ instance
+      #       # MyOperation.call(name: "Bob", age: 23) # -> Input.new(name: "Bob", age: 23)
+      #       input_constructor :new
+      #     end
+      #
+      #     MyOperation.input_constructor.is_a?(Method) #=> true
+      #
+      #   @example Custom Proc constructor
+      #     class MyOperation
+      #       include Teckel::Operation
+      #
+      #       class Input
+      #         def initialize(*args, **opts); end
+      #       end
+      #
+      #       # If you need more control over how to build a new +Input+ instance
+      #       # MyOperation.call("foo", opt: "bar") # -> Input.new(name: "foo", opt: "bar")
+      #       input_constructor ->(name, options) { Input.new(name: name, **options) }
+      #     end
+      #
+      #     MyOperation.input_constructor.is_a?(Proc) #=> true
+      def input_constructor(sym_or_proc = nil)
+        get_set_counstructor(:input_constructor, input, sym_or_proc) ||
+          raise(MissingConfigError, "Missing input_constructor config for #{self}")
+      end
+
+      # @overload output()
+      #  Get the configured class wrapping the output data structure.
+      #  Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
+      #  @return [Class] The +output+ class
+      #
+      # @overload output(klass)
+      #   Set the class wrapping the output data structure.
+      #   @param  klass [Class] The +output+ class
+      #   @return [Class] The +output+ class
+      def output(klass = nil)
+        @config.for(:output, klass) { self::Output if const_defined?(:Output) } ||
+          raise(Teckel::MissingConfigError, "Missing output config for #{self}")
+      end
+
+      # @overload output_constructor()
+      #  The callable constructor to build an instance of the +output+ class.
+      #  Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
+      #  @return [Proc] A callable that will return an instance of +output+ class.
+      #
+      # @overload output_constructor(sym_or_proc)
+      #   Define how to build the +output+.
+      #   @param sym_or_proc [Symbol, #call]
+      #     - Either a +Symbol+ representing the _public_ method to call on the +output+ class.
+      #     - Or anything that response to +#call+ (like a +Proc+).
+      #   @return [#call] The callable constructor
+      #
+      #   @example
+      #     class MyOperation
+      #       include Teckel::Operation
+      #
+      #       class Output
+      #         def initialize(*args, **opts); end
+      #       end
+      #
+      #       # MyOperation.call("foo", "bar") # -> Output.new("foo", "bar")
+      #       output_constructor :new
+      #
+      #       # If you need more control over how to build a new +Output+ instance
+      #       # MyOperation.call("foo", opt: "bar") # -> Output.new(name: "foo", opt: "bar")
+      #       output_constructor ->(name, options) { Output.new(name: name, **options) }
+      #     end
+      def output_constructor(sym_or_proc = nil)
+        get_set_counstructor(:output_constructor, output, sym_or_proc) ||
+          raise(MissingConfigError, "Missing output_constructor config for #{self}")
+      end
+
+      # @overload error()
+      #   Get the configured class wrapping the error data structure.
+      #   @return [Class] The +error+ class
+      #
+      # @overload error(klass)
+      #   Set the class wrapping the error data structure.
+      #   @param klass [Class] The +error+ class
+      #   @return [Class,nil] The +error+ class or +nil+ if it does not error
+      def error(klass = nil)
+        @config.for(:error, klass) { self::Error if const_defined?(:Error) } ||
+          raise(Teckel::MissingConfigError, "Missing error config for #{self}")
+      end
+
+      # @overload error_constructor()
+      #   The callable constructor to build an instance of the +error+ class.
+      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
+      #   @return [Proc] A callable that will return an instance of +error+ class.
+      #
+      # @overload error_constructor(sym_or_proc)
+      #   Define how to build the +error+.
+      #   @param sym_or_proc [Symbol, #call]
+      #     - Either a +Symbol+ representing the _public_ method to call on the +error+ class.
+      #     - Or anything that response to +#call+ (like a +Proc+).
+      #   @return [#call] The callable constructor
+      #
+      #   @example
+      #     class MyOperation
+      #       include Teckel::Operation
+      #
+      #       class Error
+      #         def initialize(*args, **opts); end
+      #       end
+      #
+      #       # MyOperation.call("foo", "bar") # -> Error.new("foo", "bar")
+      #       error_constructor :new
+      #
+      #       # If you need more control over how to build a new +Error+ instance
+      #       # MyOperation.call("foo", opt: "bar") # -> Error.new(name: "foo", opt: "bar")
+      #       error_constructor ->(name, options) { Error.new(name: name, **options) }
+      #     end
+      def error_constructor(sym_or_proc = nil)
+        get_set_counstructor(:error_constructor, error, sym_or_proc) ||
+          raise(MissingConfigError, "Missing error_constructor config for #{self}")
+      end
+
+      # @!endgroup
+
+      # @overload settings()
+      #  Get the configured class wrapping the settings data structure.
+      #  @return [Class] The +settings+ class, or {Teckel::Contracts::None} as default
+      #
+      # @overload settings(klass)
+      #   Set the class wrapping the settings data structure.
+      #   @param klass [Class] The +settings+ class
+      #   @return [Class] The +settings+ class configured
+      def settings(klass = nil)
+        @config.for(:settings, klass) { const_defined?(:Settings) ? self::Settings : none }
+      end
+
+      # @overload settings_constructor()
+      #   The callable constructor to build an instance of the +settings+ class.
+      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
+      #   @return [Proc] A callable that will return an instance of +settings+ class.
+      #
+      # @overload settings_constructor(sym_or_proc)
+      #  Define how to build the +settings+.
+      #  @param  sym_or_proc [Symbol, #call]
+      #    - Either a +Symbol+ representing the _public_ method to call on the +settings+ class.
+      #    - Or anything that response to +#call+ (like a +Proc+).
+      #  @return [#call] The callable constructor
+      #
+      #  @example
+      #    class MyOperation
+      #      include Teckel::Operation
+      #
+      #      class Settings
+      #        def initialize(*args); end
+      #      end
+      #
+      #      # MyOperation.with("foo", "bar") # -> Settings.new("foo", "bar")
+      #      settings_constructor :new
+      #    end
+      def settings_constructor(sym_or_proc = nil)
+        get_set_counstructor(:settings_constructor, settings, sym_or_proc) ||
+          raise(MissingConfigError, "Missing settings_constructor config for #{self}")
+      end
+
+      # @overload runner()
+      #   @return [Class] The Runner class
+      #   @!visibility protected
+      #
+      # @overload runner(klass)
+      #   Overwrite the default runner
+      #   @param klass [Class] A class like the {Runner}
+      #   @!visibility protected
+      def runner(klass = nil)
+        @config.for(:runner, klass) { Teckel::Operation::Runner }
+      end
+
+      # @overload result()
+      #   Get the configured result object class wrapping {error} or {output}.
+      #   The {ValueResult} default will act as a pass-through and does. Any error
+      #   or output will just returned as-is.
+      #   @return [Class] The +result+ class, or {ValueResult} as default
+      #
+      # @overload result(klass)
+      #   Set the result object class wrapping {error} or {output}.
+      #   @param klass [Class] The +result+ class
+      #   @return [Class] The +result+ class configured
+      def result(klass = nil)
+        @config.for(:result, klass) { const_defined?(:Result, false) ? self::Result : ValueResult }
+      end
+
+      # @overload result_constructor()
+      #   The callable constructor to build an instance of the +result+ class.
+      #   Defaults to {Teckel::DEFAULT_CONSTRUCTOR}
+      #   @return [Proc] A callable that will return an instance of +result+ class.
+      #
+      # @overload result_constructor(sym_or_proc)
+      #  Define how to build the +result+.
+      #  @param  sym_or_proc [Symbol, #call]
+      #    - Either a +Symbol+ representing the _public_ method to call on the +result+ class.
+      #    - Or anything that response to +#call+ (like a +Proc+).
+      #  @return [#call] The callable constructor
+      #
+      #  @example
+      #    class MyOperation
+      #      include Teckel::Operation
+      #
+      #      class Result
+      #        include Teckel::Result
+      #        def initialize(value, success, opts = {}); end
+      #      end
+      #
+      #      # If you need more control over how to build a new +Settings+ instance
+      #      result_constructor ->(value, success) { result.new(value, success, {foo: :bar}) }
+      #    end
+      def result_constructor(sym_or_proc = nil)
+        get_set_counstructor(:result_constructor, result, sym_or_proc) ||
+          raise(MissingConfigError, "Missing result_constructor config for #{self}")
+      end
+
+      # @!group Shortcuts
+
+      # Shortcut to use {Teckel::Operation::Result} as a result object,
+      # wrapping any {error} or {output}.
+      #
+      # @!visibility protected
+      # @note Don't use in conjunction with {result} or {result_constructor}
+      # @return [nil]
+      def result!
+        @config.for(:result, Teckel::Operation::Result)
+        @config.for(:result_constructor, Teckel::Operation::Result.method(:new))
+        nil
+      end
+
+      # @!visibility private
+      # @return [void]
+      def define!
+        %i[
+          input input_constructor
+          output output_constructor
+          error error_constructor
+          settings settings_constructor
+          result result_constructor
+          runner
+        ].each { |e| public_send(e) }
+        nil
+      end
+
+      # Disallow any further changes to this Operation.
+      # Make sure all configurations are set.
+      #
+      # @raise [MissingConfigError]
+      # @return [self] Frozen self
+      # @!visibility public
+      def finalize!
+        define!
+        @config.freeze
+        self
+      end
+
+      # Produces a shallow copy of this operation and all it's configuration.
+      #
+      # @return [self]
+      # @!visibility public
+      def dup
+        super.tap do |copy|
+          copy.instance_variable_set(:@config, @config.dup)
+        end
+      end
+
+      # Produces a clone of this operation and all it's configuration
+      #
+      # @return [self]
+      # @!visibility public
+      def clone
+        if frozen?
+          super
+        else
+          super.tap do |copy|
+            copy.instance_variable_set(:@config, @config.dup)
+          end
+        end
+      end
+
+      # @!visibility private
+      def inherited(subclass)
+        subclass.instance_variable_set(:@config, @config.dup)
+      end
+
+      # @!visibility private
+      def self.extended(base)
+        base.instance_exec do
+          @config = Teckel::Config.new
+          attr_accessor :settings
+        end
+      end
+
+      private
+
+      def get_set_counstructor(name, on, sym_or_proc)
+        constructor = build_counstructor(on, sym_or_proc) unless sym_or_proc.nil?
+
+        @config.for(name, constructor) {
+          build_counstructor(on, Teckel::DEFAULT_CONSTRUCTOR)
+        }
+      end
+
+      def build_counstructor(on, sym_or_proc)
+        if sym_or_proc.is_a?(Symbol) && on.respond_to?(sym_or_proc)
+          on.public_method(sym_or_proc)
+        elsif sym_or_proc.respond_to?(:call)
+          sym_or_proc
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
... to split up responsibilities as bit and also make the main "ClassMethods" module a bit more readable 