### PR TITLE
Default Settings

### DIFF
--- a/_pages/docs/operations/dependency_injection.md
+++ b/_pages/docs/operations/dependency_injection.md
@@ -64,3 +64,128 @@ With Logger
 .. end
 ```
 {% endfilter %}
+
+## Default Settings
+
+Initialize Setting by default.  
+This avoids `nil` settings, but forces you to either make your `Settings` class  
+accept no arguments for initialization, or provide acceptable defaults.
+
+Note that, default settings will not get merged with call time setting.
+Default settings will be ignored when calling like this: `MyOperation.with(call_time_settings).call`.
+
+{% filter remove_code_promt %}
+```ruby
+>> class BaseOperation
+..   include Teckel::Operation
+..
+..   class Settings
+..     def initialize(*values)
+..       @values = values
+..     end
+..     attr_reader :values
+..   end
+..
+..   settings_constructor :new
+..
+..   input  none
+..   output Types::Array
+..   error  none
+..
+..   def call(_)
+..     settings.values
+..   end
+.. end
+```
+{% endfilter %}
+
+### Empty defaults
+
+{% filter remove_code_promt %}
+```ruby
+>> class EmptyDefaults < BaseOperation
+..   default_settings! # Settings.new
+.. end
+```
+{% endfilter %}
+
+With no settings:
+
+{% filter remove_code_promt %}
+```ruby
+>> EmptyDefaults.call
+=> []
+```
+{% endfilter %}
+
+With injected settings:
+
+{% filter remove_code_promt %}
+```ruby
+>> EmptyDefaults.with(:injected).call
+=> [:injected]
+```
+{% endfilter %}
+
+### Static defaults
+
+{% filter remove_code_promt %}
+```ruby
+>> class StaticDefaults < BaseOperation
+..   default_settings!(:foo, :bar) # Settings.new(:foo, :bar)
+.. end
+```
+{% endfilter %}
+
+With no settings:
+
+{% filter remove_code_promt %}
+```ruby
+>> StaticDefaults.call
+=> [:foo, :bar]
+```
+{% endfilter %}
+
+With injected settings:
+
+{% filter remove_code_promt %}
+```ruby
+>> StaticDefaults.with(:injected).call
+=> [:injected]
+```
+{% endfilter %}
+
+
+### Call time defaults
+
+{% filter remove_code_promt %}
+```ruby
+>> class CallTimeDefaults < BaseOperation
+..   default_settings! -> { settings_constructor.call(Time.now) } # Settings.new(Time.now)
+.. end
+```
+{% endfilter %}
+
+With no settings:
+
+{% filter remove_code_promt %}
+```ruby
+>> a = CallTimeDefaults.call.first
+>> b = CallTimeDefaults.call.first
+>> a.class
+=> Time
+>> b.class
+=> Time
+>> a < b
+=> true
+```
+{% endfilter %}
+
+With injected settings:
+
+{% filter remove_code_promt %}
+```ruby
+>> CallTimeDefaults.with(:injected).call
+=> [:injected]
+```
+{% endfilter %}

--- a/lib/teckel/chain.rb
+++ b/lib/teckel/chain.rb
@@ -47,11 +47,12 @@ module Teckel
       def call(input = nil)
         default_settings = self.default_settings
 
-        runner = if default_settings
-          self.runner.new(self, default_settings)
-        else
-          self.runner.new(self)
-        end
+        runner =
+          if default_settings
+            self.runner.new(self, default_settings)
+          else
+            self.runner.new(self)
+          end
 
         if around
           around.call(runner, input)

--- a/lib/teckel/chain.rb
+++ b/lib/teckel/chain.rb
@@ -45,7 +45,14 @@ module Teckel
       # @return [Teckel::Chain::Result] The result object wrapping
       #   the result value, the success state and last executed step.
       def call(input = nil)
-        runner = self.runner.new(self)
+        default_settings = self.default_settings
+
+        runner = if default_settings
+          self.runner.new(self, default_settings)
+        else
+          self.runner.new(self)
+        end
+
         if around
           around.call(runner, input)
         else

--- a/lib/teckel/chain/config.rb
+++ b/lib/teckel/chain/config.rb
@@ -119,6 +119,22 @@ module Teckel
         } || raise(MissingConfigError, "Missing result_constructor config for #{self}")
       end
 
+      # Declare default settings operation iin this chain should use when called without
+      # {Teckel::Chain::ClassMethods#with #with}.
+      #
+      # Explicit call-time settings will *not* get merged with declared default setting.
+      #
+      # @param settings [Hash{String,Symbol => Object}] Set settings for a step by it's name
+      def default_settings!(settings) # :nodoc: The bang is for consistency with the Operation class
+        @config.for(:default_settings, settings)
+      end
+
+      # Getter for configured default settings
+      # @return [nil|#call] The callable constructor
+      def default_settings
+        @config.for(:default_settings)
+      end
+
       REQUIRED_CONFIGS = %i[around runner result result_constructor].freeze
 
       # @!visibility private

--- a/lib/teckel/chain/config.rb
+++ b/lib/teckel/chain/config.rb
@@ -131,7 +131,8 @@ module Teckel
       #     include Teckel::Operation
       #     result!
       #
-      #     settings Struct.new(:say, :other, keyword_init: true)
+      #     settings Struct.new(:say, :other)
+      #     settings_constructor ->(data) { settings.new(*data.values_at(*settings.members)) }
       #
       #     input none
       #     output Hash

--- a/lib/teckel/chain/config.rb
+++ b/lib/teckel/chain/config.rb
@@ -125,6 +125,38 @@ module Teckel
       # Explicit call-time settings will *not* get merged with declared default setting.
       #
       # @param settings [Hash{String,Symbol => Object}] Set settings for a step by it's name
+      #
+      # @example
+      #   class MyOperation
+      #     include Teckel::Operation
+      #     result!
+      #
+      #     settings Struct.new(:say, :other, keyword_init: true)
+      #
+      #     input none
+      #     output Hash
+      #     error none
+      #
+      #     def call(_)
+      #       settings.to_h
+      #     end
+      #   end
+      #
+      #   class Chain
+      #     include Teckel::Chain
+      #
+      #     default_settings!(a: { say: "Chain Default" })
+      #
+      #     step :a, MyOperation
+      #   end
+      #
+      #   # Using the chains default settings
+      #   result = Chain.call
+      #   result.success #=> {say: "Chain Default", other: nil}
+      #
+      #   # explicit settings passed via `with` will overwrite all defaults
+      #   result = Chain.with(a: { other: "What" }).call
+      #   result.success #=> {say: nil, other: "What"}
       def default_settings!(settings) # :nodoc: The bang is for consistency with the Operation class
         @config.for(:default_settings, settings)
       end

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -63,7 +63,13 @@ module Teckel
       # @return Either An instance of your defined {#error} class or {#output} class
       # @!visibility public
       def call(input = nil)
-        runner.new(self).call(input)
+        default_settings = self.default_settings
+
+        if default_settings
+          runner.new(self, default_settings.call)
+        else
+          runner.new(self)
+        end.call(input)
       end
 
       # Provide {InstanceMethods#settings() settings} to the running operation.

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -14,13 +14,14 @@ module Teckel
   # +input+. +output+ and +error+ methods to point them to anonymous classes.
   #
   # If you like "traditional" result objects to ask +successful?+ or +failure?+ on,
-  # use {.result!} and get {Teckel::Operation::Result}
+  # use {Teckel::Operation::Config#result! result!} and get {Teckel::Operation::Result}
   #
   # By default, +input+. +output+ and +error+ classes are build using +:[]+
   # (eg: +Input[some: :param]+).
-  # Use {ClassMethods#input_constructor input_constructor},
-  # {ClassMethods#output_constructor output_constructor} and
-  # {ClassMethods#error_constructor error_constructor} to change them.
+  #
+  # Use {Teckel::Operation::Config#input_constructor input_constructor},
+  # {Teckel::Operation::Config#output_constructor output_constructor} and
+  # {Teckel::Operation::Config#error_constructor error_constructor} to change them.
   #
   # @example class definitions via methods
   #   class CreateUserViaMethods
@@ -59,8 +60,10 @@ module Teckel
     module ClassMethods
       # Invoke the Operation
       #
-      # @param input Any form of input your {#input} class can handle via the given {#input_constructor}
-      # @return Either An instance of your defined {#error} class or {#output} class
+      # @param input Any form of input your {Teckel::Operation::Config#input input} class can handle via the given
+      #   {Teckel::Operation::Config#input_constructor input_constructor}
+      # @return Either An instance of your defined {Teckel::Operation::Config#error error} class or
+      #   {Teckel::Operation::Config#output output} class
       # @!visibility public
       def call(input = nil)
         default_settings = self.default_settings
@@ -77,8 +80,9 @@ module Teckel
       # This method is intended to be called on the operation class outside of
       # it's definition, prior to running {#call}.
       #
-      # @param input Any form of input your {#settings} class can handle via the given {#settings_constructor}
-      # @return [Class] The configured {runner}
+      # @param input Any form of input your {Teckel::Operation::Config#settings settings} class can handle via the given
+      #   {Teckel::Operation::Config#settings_constructor settings_constructor}
+      # @return [Class] The configured {Teckel::Operation::Config#runner runner}
       # @!visibility public
       #
       # @example Inject settings for an operation call
@@ -112,8 +116,11 @@ module Teckel
       end
       alias :set :with
 
-      # Convenience method for setting {#input}, {#output} or {#error} to the
+      # Convenience method for setting {Teckel::Operation::Config#input input},
+      # {Teckel::Operation::Config#output output} or
+      # {Teckel::Operation::Config#error error} to the
       # {Teckel::Contracts::None} value.
+      #
       # @return [Object] The {Teckel::Contracts::None} class.
       #
       # @example Enforcing nil input, output or error
@@ -154,7 +161,7 @@ module Teckel
 
       # Halt any further execution with a output value
       #
-      # @return a thing matching your {Operation::ClassMethods#output Operation#output} definition
+      # @return a thing matching your {Teckel::Operation::Config#output output} definition
       # @!visibility protected
       def success!(*args)
         throw :success, args
@@ -162,7 +169,7 @@ module Teckel
 
       # Halt any further execution with an error value
       #
-      # @return a thing matching your {Operation::ClassMethods#error Operation#error} definition
+      # @return a thing matching your {Teckel::Operation::Config#error error} definition
       # @!visibility protected
       def fail!(*args)
         throw :failure, args

--- a/spec/chain/default_settings_spec.rb
+++ b/spec/chain/default_settings_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Teckel::Chain do
+  module TeckelChainDefaultSettingsTest
+    class MyOperation
+      include Teckel::Operation
+      result!
+
+      settings Struct.new(:say, :other)
+      settings_constructor ->(data) { settings.new(*data.values_at(*settings.members)) } # ruby 2.4 way for `keyword_init: true`
+
+      input none
+      output Hash
+      error none
+
+      def call(_)
+        settings.to_h
+      end
+    end
+
+    class Chain
+      include Teckel::Chain
+
+      default_settings!(a: { say: "Chain Default" })
+
+      step :a, MyOperation
+    end
+  end
+
+  specify "call chain without settings, uses default settings" do
+    result = TeckelChainDefaultSettingsTest::Chain.call
+    expect(result.success).to eq(say: "Chain Default", other: nil)
+  end
+
+  specify "call chain with explicit settings, overwrites defaults" do
+    result = TeckelChainDefaultSettingsTest::Chain.with(a: { other: "What" }).call
+    expect(result.success).to eq(say: nil, other: "What")
+  end
+end

--- a/spec/operation/default_settings_spec.rb
+++ b/spec/operation/default_settings_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe Teckel::Operation do
+  context "default settings" do
+    module TeckelOperationDefaultSettings
+      class BaseOperation
+        include ::Teckel::Operation
+
+        input none
+        output Symbol
+        error none
+
+        def call(_input)
+          success! settings.injected
+        end
+      end
+    end
+
+    shared_examples "operation with default settings" do |operation|
+      subject { operation }
+
+      it "with no settings" do
+        expect(subject.call).to eq(:default_value)
+      end
+
+      it "with settings" do
+        expect(subject.with(:injected_value).call).to eq(:injected_value)
+      end
+    end
+
+    describe "with default constructor and clever Settings class" do
+      it_behaves_like(
+        "operation with default settings",
+        Class.new(TeckelOperationDefaultSettings::BaseOperation) do
+          settings(Class.new do
+            def initialize(injected = nil)
+              @injected = injected
+            end
+
+            def injected
+              @injected || :default_value
+            end
+
+            class << self
+              alias :[] :new # make us respond to the default constructor
+            end
+          end)
+
+          default_settings!
+        end
+      )
+    end
+
+    describe "with custom constructor and clever Settings class" do
+      it_behaves_like(
+        "operation with default settings",
+        Class.new(TeckelOperationDefaultSettings::BaseOperation) do
+          settings(Class.new do
+            def initialize(injected = nil)
+              @injected = injected
+            end
+
+            def injected
+              @injected || :default_value
+            end
+          end)
+
+          settings_constructor :new
+          default_settings!
+        end
+      )
+    end
+
+    describe "with default constructor and simple Settings class" do
+      it_behaves_like(
+        "operation with default settings",
+        Class.new(TeckelOperationDefaultSettings::BaseOperation) do
+          settings Struct.new(:injected)
+
+          default_settings! -> { settings.new(:default_value) }
+        end
+      )
+
+      it_behaves_like(
+        "operation with default settings",
+        Class.new(TeckelOperationDefaultSettings::BaseOperation) do
+          settings Struct.new(:injected)
+
+          default_settings!(:default_value)
+        end
+      )
+    end
+  end
+end


### PR DESCRIPTION
fixes #17 

- [x] Operations
- [x] Chains

The API is a bit different from the original proposal. Declaring default setting always use the bang method (`default_settings!`, `default_settings!(:default, :arguments)` or `default_settings! -> { Settings.new(...) }` )