### PR TITLE
Move Operation success! and fail! logic into runner

### DIFF
--- a/.github/workflows/pages_specs.yml
+++ b/.github/workflows/pages_specs.yml
@@ -1,0 +1,38 @@
+name: Pages Specs
+
+on:
+  push:
+    paths:
+      - .github/workflows/ci.yml
+      - _pages/**
+      - lib/**
+      - spec/**
+      - Gemfile
+      - "*.gemspec"
+      - ".rubocop.yml"
+
+jobs:
+  pages_doc_test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+    - name: Setup python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Bundle install
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3 --without test
+    - name: Install mkdocs and byexample requirements
+      run: |
+        pip3 install -r _pages/requirements.txt
+    - name: Test doc samples
+      run: ./bin/byexample

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Specs & Lint
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
       - ".rubocop.yml"
 
 jobs:
-  rubocop:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.rubocop-https---relaxed-ruby-style-rubocop-yml
+++ b/.rubocop-https---relaxed-ruby-style-rubocop-yml
@@ -1,5 +1,5 @@
 # Relaxed.Ruby.Style
-## Version 2.4
+## Version 2.5
 
 Style/Alias:
   Enabled: false
@@ -145,30 +145,9 @@ Lint/AssignmentInCondition:
   Enabled: false
   StyleGuide: https://relaxed.ruby.style/#lintassignmentincondition
 
-Metrics/AbcSize:
-  Enabled: false
-
-Metrics/BlockNesting:
-  Enabled: false
-
-Metrics/ClassLength:
-  Enabled: false
-
-Metrics/ModuleLength:
-  Enabled: false
-
-Metrics/CyclomaticComplexity:
-  Enabled: false
-
 Layout/LineLength:
   Enabled: false
 
-Metrics/MethodLength:
-  Enabled: false
-
-Metrics/ParameterLists:
-  Enabled: false
-
-Metrics/PerceivedComplexity:
+Metrics:
   Enabled: false
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,3 +14,10 @@
   ```
 
 - 
+
+## Building docs
+
+* make sure to have python3 installed
+* Install dependencies: `pip3 install -r _pages/requirements.txt`
+* Test doc samples: `./bin/byexample`
+* Build pages: `cd _pages && mkdocs build --strict`

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 group :development, :test do
-  gem "irb", ">= 1.2", platform: :mri if RUBY_VERSION >= '2.5'
+  gem "irb", ">= 1.2.7", "< 2", platform: :mri if RUBY_VERSION >= '2.5'
   gem "dry-struct", ">= 1.1.1", "< 2"
   gem "dry-monads", ">= 1.3", "< 2"
 end

--- a/_pages/docs/chains/around.md
+++ b/_pages/docs/chains/around.md
@@ -36,7 +36,7 @@ There hooks gets total control over the execution, so it needs to take care of c
 ..     if settings&.fail_befriend == :fail
 ..       fail!(message: "Did not find a friend.")
 ..     else
-..       { user: user, friend: User.new(name: "A friend", age: 42) }
+..       success!(user: user, friend: User.new(name: "A friend", age: 42))
 ..     end
 ..   end
 .. end

--- a/_pages/docs/chains/basics.md
+++ b/_pages/docs/chains/basics.md
@@ -44,7 +44,7 @@ Defining a simple Chain with three steps.
 ..
 ..   def call(usr)
 ..     Logger.new(File::NULL).info("User #{usr.name} created")
-..     usr # we need to return the correct output type
+..     success!(usr) # we need to return the correct output type
 ..   end
 .. end
 
@@ -63,7 +63,7 @@ Defining a simple Chain with three steps.
 ..     if settings&.fail_befriend == :fail
 ..       fail!(message: "Did not find a friend.")
 ..     else
-..       { user: user, friend: User.new(name: "A friend", age: 42) }
+..       success!(user: user, friend: User.new(name: "A friend", age: 42))
 ..     end
 ..   end
 .. end

--- a/_pages/docs/docs_base.rb
+++ b/_pages/docs/docs_base.rb
@@ -4,7 +4,7 @@ require "English"
 require 'dry-types'
 require 'dry-struct'
 
-Warning[:experimental] = false
+Warning[:experimental] = false if Warning.respond_to? :[]
 
 module Types
   include Dry.Types()

--- a/_pages/docs/operations/basics.md
+++ b/_pages/docs/operations/basics.md
@@ -30,7 +30,7 @@
 ..   def call(input)
 ..     user = ::User.new(name: input.name, age: input.age)
 ..     if user.save
-..       user
+..       success!(user)
 ..     else
 ..       fail!("Could not save User", user.errors)
 ..     end
@@ -148,12 +148,13 @@ If your contracts support Feed an instance of the input class directly to call:
 ..     if settings
 ..       fail!(nil)             if settings.err == :nil
 ..       success!(nil)          if settings.out == :nil
+..       fail!                  if settings.err == :nothing
+..       success!               if settings.out == :nothing
 ..       fail!(settings.err)    if settings.err
 ..       success!(settings.out) if settings.out
 ..       
-..       settings.ret
+..       settings.ret # any normal return value will be ignored
 ..     end
-..     # make sure no value is returned here.
 ..   end
 .. end
 ```
@@ -174,21 +175,27 @@ Expects to be called with nothing or `nil`, calling with any value will raise an
 ```
 {% endfilter %}
 
-Expects no success value, that include any return value:
+Expects no success value:
 
 {% filter remove_code_promt %}
 ```ruby
+>> NoOp.call
+=> nil
+
 >> NoOp.with(out: nil).call
 => nil
 
 >> NoOp.with(out: :nil).call
 => nil
 
+>> NoOp.with(out: :nothing).call
+=> nil
+
 >> NoOp.with(out: "test").call rescue $ERROR_INFO
 => #<ArgumentError: None called with arguments>
 
->> NoOp.with(ret: "test").call rescue $ERROR_INFO
-=> #<ArgumentError: None called with arguments>
+>> NoOp.with(ret: "test").call # return values will be ignored
+=> nil
 ```
 {% endfilter %}
 
@@ -200,6 +207,9 @@ Expects no failure value:
 => nil
 
 >> NoOp.with(err: :nil).call
+=> nil
+
+>> NoOp.with(err: :nothing).call
 => nil
 
 >> NoOp.with(err: "test").call rescue $ERROR_INFO

--- a/_pages/docs/operations/dependency_injection.md
+++ b/_pages/docs/operations/dependency_injection.md
@@ -18,7 +18,6 @@ Settings (just as input, output and error) are defined using a contract class an
 ..   def call(_input)
 ..     puts "no settings" if settings.nil?
 ..     settings.logger.puts "called" if settings&.logger
-..     nil
 ..   end
 .. end
 ```
@@ -93,7 +92,7 @@ Default settings will be ignored when calling like this: `MyOperation.with(call_
 ..   error  none
 ..
 ..   def call(_)
-..     settings.values
+..     success!(settings.values)
 ..   end
 .. end
 ```

--- a/bin/byexample
+++ b/bin/byexample
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if ! (ruby --version | grep -q '^ruby 2.7.'); then
+	echo "Because of irb and ruby shenanigans, we need ruby 2.7"
+	exit 1
+fi
+
 irb_opts="-f --nomultiline --nocolorize"
 irb_r="-r bundler/setup"
 irb_r+=" -r ./_pages/docs/docs_base.rb"

--- a/bin/mkdocs
+++ b/bin/mkdocs
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd _pages
+mkdocs build --strict
+cd -

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -10,8 +10,7 @@ require 'bundler'
 Bundler.settings.temporary(frozen: false) do
   gemfile do
     source 'https://rubygems.org'
-    gem 'rubocop', '~> 0.78.0'
-    gem 'relaxed-rubocop', '2.4'
+    gem 'rubocop', '~> 1.0.0'
   end
 end
 

--- a/lib/teckel/chain/config.rb
+++ b/lib/teckel/chain/config.rb
@@ -41,7 +41,7 @@ module Teckel
       #     output input
       #
       #     def call(hsh)
-      #       hsh
+      #       success!(hsh)
       #     end
       #   end
       #
@@ -139,7 +139,7 @@ module Teckel
       #     error none
       #
       #     def call(_)
-      #       settings.to_h
+      #       success!(settings.to_h)
       #     end
       #   end
       #
@@ -216,7 +216,7 @@ module Teckel
 
       # @!visibility private
       def inherited(subclass)
-        dup_config(subclass)
+        super dup_config(subclass)
       end
 
       # @!visibility private

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -140,9 +140,6 @@ module Teckel
       #
       #       # when using `output none`:
       #       # `success!` works, but `success!("data")` raises an error
-      #       # same thing when using simple return values as success:
-      #       # take care to not return anything
-      #       nil
       #     end
       #   end
       #
@@ -153,23 +150,36 @@ module Teckel
     end
 
     module InstanceMethods
+      # @!method call(input)
+      # @abstract
+      # @see Operation
+      # @see ClassMethods#call
+      #
+      # The entry point for your operation. It needs to always accept an input value, even when
+      # using +input none+.
+      # If your Operation expects to generate success or failure outputs, you need to use either
+      # {.success!} or {.fail!} respectively. Simple return values will get ignored by default. See
+      # {Teckel::Operation::Config#runner} and {Teckel::Operation::Runner} on how to overwrite.
+
       # @!attribute [r] settings()
       # @return [Class,nil] When executed with settings, an instance of the
       #   configured {.settings} class. Otherwise +nil+
       # @see ClassMethods#settings
       # @!visibility public
 
-      # Halt any further execution with a output value
+      # Delegates to the configured Runner.
+      # The default behavior is to halt any further execution with a output value.
       #
-      # @return a thing matching your {Teckel::Operation::Config#output output} definition
+      # @see Teckel::Operation::Runner#success!
       # @!visibility protected
       def success!(*args)
         runner.success!(*args)
       end
 
-      # Halt any further execution with an error value
+      # Delegates to the configured Runner.
+      # The default behavior is to halt any further execution with an error value.
       #
-      # @return a thing matching your {Teckel::Operation::Config#error error} definition
+      # @see Teckel::Operation::Runner#fail!
       # @!visibility protected
       def fail!(*args)
         runner.fail!(*args)

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -164,7 +164,7 @@ module Teckel
       # @return a thing matching your {Teckel::Operation::Config#output output} definition
       # @!visibility protected
       def success!(*args)
-        throw :success, args
+        runner.success!(*args)
       end
 
       # Halt any further execution with an error value
@@ -172,7 +172,7 @@ module Teckel
       # @return a thing matching your {Teckel::Operation::Config#error error} definition
       # @!visibility protected
       def fail!(*args)
-        throw :failure, args
+        runner.fail!(*args)
       end
     end
 

--- a/lib/teckel/operation/config.rb
+++ b/lib/teckel/operation/config.rb
@@ -362,6 +362,7 @@ module Teckel
       # @!visibility private
       def inherited(subclass)
         subclass.instance_variable_set(:@config, @config.dup)
+        super subclass
       end
 
       # @!visibility private

--- a/lib/teckel/operation/config.rb
+++ b/lib/teckel/operation/config.rb
@@ -368,6 +368,7 @@ module Teckel
       def self.extended(base)
         base.instance_exec do
           @config = Teckel::Config.new
+          attr_accessor :runner
           attr_accessor :settings
         end
       end

--- a/lib/teckel/operation/runner.rb
+++ b/lib/teckel/operation/runner.rb
@@ -21,9 +21,16 @@ module Teckel
           out = catch(:success) do
             simple_return = run(build_input(input))
           end
-          return simple_return == UNDEFINED ? build_output(*out) : build_output(simple_return)
+
+          if simple_return != UNDEFINED
+            Kernel.warn "[Deprecated] #{operation}#call Simple return values for Teckel Operations are deprecated. Use `success!` instead."
+            return build_output(simple_return)
+          end
+
+          return out
         end
-        build_error(*err)
+
+        err
       end
 
       # This is just here to raise a meaningful error.
@@ -32,10 +39,21 @@ module Teckel
         raise Teckel::Error, "Operation already has settings assigned."
       end
 
+      def success!(*args)
+        output = build_output(*args)
+        throw :success, output
+      end
+
+      def fail!(*args)
+        output = build_error(*args)
+        throw :failure, output
+      end
+
       private
 
       def run(input)
         op = @operation.new
+        op.runner = self
         op.settings = settings if settings != UNDEFINED
         op.call(input)
       end

--- a/spec/chain/default_settings_spec.rb
+++ b/spec/chain/default_settings_spec.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
-RSpec.describe Teckel::Chain do
-  module TeckelChainDefaultSettingsTest
-    class MyOperation
-      include Teckel::Operation
-      result!
+module TeckelChainDefaultSettingsTest
+  class MyOperation
+    include Teckel::Operation
+    result!
 
-      settings Struct.new(:say, :other)
-      settings_constructor ->(data) { settings.new(*data.values_at(*settings.members)) } # ruby 2.4 way for `keyword_init: true`
+    settings Struct.new(:say, :other)
+    settings_constructor ->(data) { settings.new(*data.values_at(*settings.members)) } # ruby 2.4 way for `keyword_init: true`
 
-      input none
-      output Hash
-      error none
+    input none
+    output Hash
+    error none
 
-      def call(_)
-        settings.to_h
-      end
-    end
-
-    class Chain
-      include Teckel::Chain
-
-      default_settings!(a: { say: "Chain Default" })
-
-      step :a, MyOperation
+    def call(_)
+      success! settings.to_h
     end
   end
 
+  class Chain
+    include Teckel::Chain
+
+    default_settings!(a: { say: "Chain Default" })
+
+    step :a, MyOperation
+  end
+end
+
+RSpec.describe Teckel::Chain do
   specify "call chain without settings, uses default settings" do
     result = TeckelChainDefaultSettingsTest::Chain.call
     expect(result.success).to eq(say: "Chain Default", other: nil)

--- a/spec/chain/inheritance_spec.rb
+++ b/spec/chain/inheritance_spec.rb
@@ -3,72 +3,72 @@
 require 'support/dry_base'
 require 'support/fake_models'
 
-RSpec.describe Teckel::Chain do
-  module TeckelChainDefaultsViaBaseClass
-    LOG = [] # rubocop:disable Style/MutableConstant
+module TeckelChainDefaultsViaBaseClass
+  LOG = [] # rubocop:disable Style/MutableConstant
 
-    class LoggingChain
-      include Teckel::Chain
+  class LoggingChain
+    include Teckel::Chain
 
-      around do |chain, input|
-        require 'benchmark'
-        result = nil
-        LOG << Benchmark.measure { result = chain.call(input) }
-        result
-      end
-
-      freeze
+    around do |chain, input|
+      require 'benchmark'
+      result = nil
+      LOG << Benchmark.measure { result = chain.call(input) }
+      result
     end
 
-    class OperationA
-      include Teckel::Operation
-
-      result!
-
-      input none
-      output Types::Integer
-      error none
-
-      def call(_)
-        rand(1000)
-      end
-
-      finalize!
-    end
-
-    class OperationB
-      include Teckel::Operation
-
-      result!
-
-      input none
-      output Types::String
-      error none
-
-      def call(_)
-        ("a".."z").to_a.sample
-      end
-
-      finalize!
-    end
-
-    class ChainA < LoggingChain
-      step :roll, OperationA
-
-      finalize!
-    end
-
-    class ChainB < LoggingChain
-      step :say, OperationB
-
-      finalize!
-    end
-
-    class ChainC < ChainB
-      finalize!
-    end
+    freeze
   end
 
+  class OperationA
+    include Teckel::Operation
+
+    result!
+
+    input none
+    output Types::Integer
+    error none
+
+    def call(_)
+      success! rand(1000)
+    end
+
+    finalize!
+  end
+
+  class OperationB
+    include Teckel::Operation
+
+    result!
+
+    input none
+    output Types::String
+    error none
+
+    def call(_)
+      success! ("a".."z").to_a.sample
+    end
+
+    finalize!
+  end
+
+  class ChainA < LoggingChain
+    step :roll, OperationA
+
+    finalize!
+  end
+
+  class ChainB < LoggingChain
+    step :say, OperationB
+
+    finalize!
+  end
+
+  class ChainC < ChainB
+    finalize!
+  end
+end
+
+RSpec.describe Teckel::Chain do
   before do
     TeckelChainDefaultsViaBaseClass::LOG.clear
   end

--- a/spec/chain/none_input_spec.rb
+++ b/spec/chain/none_input_spec.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
-RSpec.describe Teckel::Chain do
-  module TeckelChainNoneInputTest
-    class MyOperation
-      include Teckel::Operation
-      result!
+module TeckelChainNoneInputTest
+  class MyOperation
+    include Teckel::Operation
+    result!
 
-      settings Struct.new(:say)
+    settings Struct.new(:say)
 
-      input none
-      output String
-      error none
+    input none
+    output String
+    error none
 
-      def call(_)
-        settings&.say || "Called"
-      end
-    end
-
-    class Chain
-      include Teckel::Chain
-
-      step :a, MyOperation
+    def call(_)
+      success!(settings&.say || "Called")
     end
   end
 
+  class Chain
+    include Teckel::Chain
+
+    step :a, MyOperation
+  end
+end
+
+RSpec.describe Teckel::Chain do
   specify "call chain without input value" do
     result = TeckelChainNoneInputTest::Chain.call
     expect(result.success).to eq("Called")

--- a/spec/chain/results_spec.rb
+++ b/spec/chain/results_spec.rb
@@ -3,47 +3,47 @@
 require 'support/dry_base'
 require 'support/fake_models'
 
-RSpec.describe Teckel::Chain do
-  module TeckelChainResultTest
-    class Message
-      include ::Teckel::Operation
+module TeckelChainResultTest
+  class Message
+    include ::Teckel::Operation
 
-      result!
+    result!
 
-      input Types::Hash.schema(message: Types::String)
-      error none
-      output Types::String
+    input Types::Hash.schema(message: Types::String)
+    error none
+    output Types::String
 
-      def call(input)
-        input[:message].upcase
-      end
-    end
-
-    class Chain
-      include Teckel::Chain
-
-      step :message, Message
-
-      class Result < Teckel::Operation::Result
-        def initialize(value, success, step, opts = {})
-          super(value, success)
-          @step = step
-          @opts = opts
-        end
-
-        class << self
-          alias :[] :new # Alias the default constructor to :new
-        end
-
-        attr_reader :opts, :step
-      end
-
-      result_constructor ->(value, success, step) {
-        result.new(value, success, step, time: Time.now.to_i)
-      }
+    def call(input)
+      success! input[:message].upcase
     end
   end
 
+  class Chain
+    include Teckel::Chain
+
+    step :message, Message
+
+    class Result < Teckel::Operation::Result
+      def initialize(value, success, step, opts = {})
+        super(value, success)
+        @step = step
+        @opts = opts
+      end
+
+      class << self
+        alias :[] :new # Alias the default constructor to :new
+      end
+
+      attr_reader :opts, :step
+    end
+
+    result_constructor ->(value, success, step) {
+      result.new(value, success, step, time: Time.now.to_i)
+    }
+  end
+end
+
+RSpec.describe Teckel::Chain do
   specify do
     result = TeckelChainResultTest::Chain.call(message: "Hello World!")
     expect(result).to be_successful

--- a/spec/chain_around_hook_spec.rb
+++ b/spec/chain_around_hook_spec.rb
@@ -4,77 +4,77 @@ require 'support/dry_base'
 require 'support/fake_db'
 require 'support/fake_models'
 
-RSpec.describe Teckel::Chain do
-  module TeckelChainAroundHookTest
-    class CreateUser
-      include ::Teckel::Operation
+module TeckelChainAroundHookTest
+  class CreateUser
+    include ::Teckel::Operation
 
-      result!
+    result!
 
-      input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer.optional)
-      output Types.Instance(User)
-      error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
+    input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer.optional)
+    output Types.Instance(User)
+    error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
 
-      def call(input)
-        user = User.new(name: input[:name], age: input[:age])
-        if user.save
-          success!(user)
-        else
-          fail!(message: "Could not safe User", errors: user.errors)
-        end
+    def call(input)
+      user = User.new(name: input[:name], age: input[:age])
+      if user.save
+        success!(user)
+      else
+        fail!(message: "Could not safe User", errors: user.errors)
       end
-    end
-
-    class AddFriend
-      include ::Teckel::Operation
-
-      result!
-
-      settings Struct.new(:fail_befriend)
-
-      input Types.Instance(User)
-      output Types::Hash.schema(user: Types.Instance(User), friend: Types.Instance(User))
-      error  Types::Hash.schema(message: Types::String)
-
-      def call(user)
-        if settings&.fail_befriend
-          fail!(message: "Did not find a friend.")
-        else
-          { user: user, friend: User.new(name: "A friend", age: 42) }
-        end
-      end
-    end
-
-    @stack = []
-    def self.stack
-      @stack
-    end
-
-    class Chain
-      include Teckel::Chain
-
-      around ->(chain, input) {
-        result = nil
-        begin
-          TeckelChainAroundHookTest.stack << :before
-
-          FakeDB.transaction do
-            result = chain.call(input)
-            raise FakeDB::Rollback if result.failure?
-          end
-
-          TeckelChainAroundHookTest.stack << :after
-          result
-        rescue FakeDB::Rollback
-          result
-        end
-      }
-
-      step :create, CreateUser
-      step :befriend, AddFriend
     end
   end
 
+  class AddFriend
+    include ::Teckel::Operation
+
+    result!
+
+    settings Struct.new(:fail_befriend)
+
+    input Types.Instance(User)
+    output Types::Hash.schema(user: Types.Instance(User), friend: Types.Instance(User))
+    error  Types::Hash.schema(message: Types::String)
+
+    def call(user)
+      if settings&.fail_befriend
+        fail!(message: "Did not find a friend.")
+      else
+        success! user: user, friend: User.new(name: "A friend", age: 42)
+      end
+    end
+  end
+
+  @stack = []
+  def self.stack
+    @stack
+  end
+
+  class Chain
+    include Teckel::Chain
+
+    around ->(chain, input) {
+      result = nil
+      begin
+        TeckelChainAroundHookTest.stack << :before
+
+        FakeDB.transaction do
+          result = chain.call(input)
+          raise FakeDB::Rollback if result.failure?
+        end
+
+        TeckelChainAroundHookTest.stack << :after
+        result
+      rescue FakeDB::Rollback
+        result
+      end
+    }
+
+    step :create, CreateUser
+    step :befriend, AddFriend
+  end
+end
+
+RSpec.describe Teckel::Chain do
   before { TeckelChainAroundHookTest.stack.clear }
 
   context "success" do

--- a/spec/chain_spec.rb
+++ b/spec/chain_spec.rb
@@ -3,70 +3,70 @@
 require 'support/dry_base'
 require 'support/fake_models'
 
-RSpec.describe Teckel::Chain do
-  module TeckelChainTest
-    class CreateUser
-      include ::Teckel::Operation
-      result!
+module TeckelChainTest
+  class CreateUser
+    include ::Teckel::Operation
+    result!
 
-      input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer.optional)
-      output Types.Instance(User)
-      error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
+    input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer.optional)
+    output Types.Instance(User)
+    error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
 
-      def call(input)
-        user = User.new(name: input[:name], age: input[:age])
-        if user.save
-          success!(user)
-        else
-          fail!(message: "Could not save User", errors: user.errors)
-        end
+    def call(input)
+      user = User.new(name: input[:name], age: input[:age])
+      if user.save
+        success!(user)
+      else
+        fail!(message: "Could not save User", errors: user.errors)
       end
-    end
-
-    class LogUser
-      include ::Teckel::Operation
-
-      result!
-
-      input Types.Instance(User)
-      error none
-      output input
-
-      def call(usr)
-        Logger.new(File::NULL).info("User #{usr.name} created")
-        usr
-      end
-    end
-
-    class AddFriend
-      include ::Teckel::Operation
-
-      result!
-
-      settings Struct.new(:fail_befriend)
-
-      input Types.Instance(User)
-      output Types::Hash.schema(user: Types.Instance(User), friend: Types.Instance(User))
-      error  Types::Hash.schema(message: Types::String)
-
-      def call(user)
-        if settings&.fail_befriend
-          fail!(message: "Did not find a friend.")
-        else
-          { user: user, friend: User.new(name: "A friend", age: 42) }
-        end
-      end
-    end
-
-    class Chain
-      include Teckel::Chain
-
-      step :create, CreateUser
-      step :log, LogUser
-      step :befriend, AddFriend
     end
   end
 
+  class LogUser
+    include ::Teckel::Operation
+
+    result!
+
+    input Types.Instance(User)
+    error none
+    output input
+
+    def call(usr)
+      Logger.new(File::NULL).info("User #{usr.name} created")
+      success! usr
+    end
+  end
+
+  class AddFriend
+    include ::Teckel::Operation
+
+    result!
+
+    settings Struct.new(:fail_befriend)
+
+    input Types.Instance(User)
+    output Types::Hash.schema(user: Types.Instance(User), friend: Types.Instance(User))
+    error  Types::Hash.schema(message: Types::String)
+
+    def call(user)
+      if settings&.fail_befriend
+        fail!(message: "Did not find a friend.")
+      else
+        success! user: user, friend: User.new(name: "A friend", age: 42)
+      end
+    end
+  end
+
+  class Chain
+    include Teckel::Chain
+
+    step :create, CreateUser
+    step :log, LogUser
+    step :befriend, AddFriend
+  end
+end
+
+RSpec.describe Teckel::Chain do
   it 'Chain input points to first step input' do
     expect(TeckelChainTest::Chain.input).to eq(TeckelChainTest::CreateUser.input)
   end

--- a/spec/operation/contract_trace_spec.rb
+++ b/spec/operation/contract_trace_spec.rb
@@ -1,84 +1,85 @@
 # frozen_string_literal: true
 
 require 'support/dry_base'
-RSpec.describe Teckel::Operation do
-  context "contract errors include meaningful trace" do
-    module TeckelOperationContractTrace
-      DefaultError = Struct.new(:message, :status_code)
-      Settings = Struct.new(:fail_it)
 
-      class ApplicationOperation
-        include Teckel::Operation
+module TeckelOperationContractTrace
+  DefaultError = Struct.new(:message, :status_code)
+  Settings = Struct.new(:fail_it)
 
-        class Input < Dry::Struct
-          attribute :input_data, Types::String
-        end
+  class ApplicationOperation
+    include Teckel::Operation
 
-        class Output < Dry::Struct
-          attribute :output_data, Types::String
-        end
-
-        class Error < Dry::Struct
-          attribute :error_data, Types::String
-        end
-
-        # Freeze the base class to make sure it's inheritable configuration is not altered
-        freeze
-      end
+    class Input < Dry::Struct
+      attribute :input_data, Types::String
     end
 
-    # Hack to get reliable stack traces
-    eval <<~RUBY, binding, "operation_success_error.rb"
-      module TeckelOperationContractTrace
-        class OperationSuccessError < ApplicationOperation
-          # Includes a deliberate bug while crating a success output
-          def call(input)
-            success!(incorrect_key: 1)
-          end
-        end
-      end
-    RUBY
+    class Output < Dry::Struct
+      attribute :output_data, Types::String
+    end
 
-    eval <<~RUBY, binding, "operation_simple_success_error.rb"
-      module TeckelOperationContractTrace
-        class OperationSimpleSuccessError < ApplicationOperation
-          # Includes a deliberate bug while crating a success output
-          def call(input)
-            return { incorrect_key: 1 }
-          end
-        end
-      end
-    RUBY
+    class Error < Dry::Struct
+      attribute :error_data, Types::String
+    end
 
-    eval <<~RUBY, binding, "operation_failure_error.rb"
-      module TeckelOperationContractTrace
-        class OperationFailureError < ApplicationOperation
-          # Includes a deliberate bug while crating an error output
-          def call(input)
-            fail!(incorrect_key: 1)
-          end
-        end
-      end
-    RUBY
+    # Freeze the base class to make sure it's inheritable configuration is not altered
+    freeze
+  end
+end
 
-    eval <<~RUBY, binding, "operation_ok.rb"
-      module TeckelOperationContractTrace
-        class OperationOk < ApplicationOperation
-          def call(input)
-            success!(output_data: "all fine")
-          end
-        end
+# Hack to get reliable stack traces
+eval <<~RUBY, binding, "operation_success_error.rb"
+  module TeckelOperationContractTrace
+    class OperationSuccessError < ApplicationOperation
+      # Includes a deliberate bug while crating a success output
+      def call(input)
+        success!(incorrect_key: 1)
       end
-    RUBY
+    end
+  end
+RUBY
 
-    eval <<~RUBY, binding, "operation_input_error.rb"
-      module TeckelOperationContractTrace
-        def self.run_operation(operation)
-          operation.call(error_input_data: "failure")
-        end
+eval <<~RUBY, binding, "operation_simple_success_error.rb"
+  module TeckelOperationContractTrace
+    class OperationSimpleSuccessNil < ApplicationOperation
+      # Includes a deliberate bug while crating a success output
+      def call(input)
+        return { incorrect_key: 1 }
       end
-    RUBY
+    end
+  end
+RUBY
 
+eval <<~RUBY, binding, "operation_failure_error.rb"
+  module TeckelOperationContractTrace
+    class OperationFailureError < ApplicationOperation
+      # Includes a deliberate bug while crating an error output
+      def call(input)
+        fail!(incorrect_key: 1)
+      end
+    end
+  end
+RUBY
+
+eval <<~RUBY, binding, "operation_ok.rb"
+  module TeckelOperationContractTrace
+    class OperationOk < ApplicationOperation
+      def call(input)
+        success!(output_data: "all fine")
+      end
+    end
+  end
+RUBY
+
+eval <<~RUBY, binding, "operation_input_error.rb"
+  module TeckelOperationContractTrace
+    def self.run_operation(operation)
+      operation.call(error_input_data: "failure")
+    end
+  end
+RUBY
+
+RSpec.describe Teckel::Operation do
+  context "contract errors include meaningful trace" do
     specify "incorrect success" do
       expect {
         TeckelOperationContractTrace::OperationSuccessError.call(input_data: "ok")
@@ -87,13 +88,10 @@ RSpec.describe Teckel::Operation do
       }
     end
 
-    specify "incorrect success via simple return prints warning with class name, but no meaningful trace" do
-      expect {
-        TeckelOperationContractTrace::OperationSimpleSuccessError.call(input_data: "ok")
-      }.to output(
-        "[Deprecated] TeckelOperationContractTrace::OperationSimpleSuccessError#call " \
-        "Simple return values for Teckel Operations are deprecated. Use `success!` instead.\n"
-      ).to_stderr.and raise_error(Dry::Struct::Error)
+    specify "incorrect success via simple return results in +nil+, but no meaningful trace" do
+      expect(
+        TeckelOperationContractTrace::OperationSimpleSuccessNil.call(input_data: "ok")
+      ).to be_nil
     end
 
     specify "incorrect fail" do

--- a/spec/operation/contract_trace_spec.rb
+++ b/spec/operation/contract_trace_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'support/dry_base'
+RSpec.describe Teckel::Operation do
+  context "contract errors include meaningful trace" do
+    module TeckelOperationContractTrace
+      DefaultError = Struct.new(:message, :status_code)
+      Settings = Struct.new(:fail_it)
+
+      class ApplicationOperation
+        include Teckel::Operation
+
+        class Input < Dry::Struct
+          attribute :input_data, Types::String
+        end
+
+        class Output < Dry::Struct
+          attribute :output_data, Types::String
+        end
+
+        class Error < Dry::Struct
+          attribute :error_data, Types::String
+        end
+
+        # Freeze the base class to make sure it's inheritable configuration is not altered
+        freeze
+      end
+    end
+
+    # Hack to get reliable stack traces
+    eval <<~RUBY, binding, "operation_success_error.rb"
+      module TeckelOperationContractTrace
+        class OperationSuccessError < ApplicationOperation
+          # Includes a deliberate bug while crating a success output
+          def call(input)
+            success!(incorrect_key: 1)
+          end
+        end
+      end
+    RUBY
+
+    eval <<~RUBY, binding, "operation_simple_success_error.rb"
+      module TeckelOperationContractTrace
+        class OperationSimpleSuccessError < ApplicationOperation
+          # Includes a deliberate bug while crating a success output
+          def call(input)
+            return { incorrect_key: 1 }
+          end
+        end
+      end
+    RUBY
+
+    eval <<~RUBY, binding, "operation_failure_error.rb"
+      module TeckelOperationContractTrace
+        class OperationFailureError < ApplicationOperation
+          # Includes a deliberate bug while crating an error output
+          def call(input)
+            fail!(incorrect_key: 1)
+          end
+        end
+      end
+    RUBY
+
+    eval <<~RUBY, binding, "operation_ok.rb"
+      module TeckelOperationContractTrace
+        class OperationOk < ApplicationOperation
+          def call(input)
+            success!(output_data: "all fine")
+          end
+        end
+      end
+    RUBY
+
+    eval <<~RUBY, binding, "operation_input_error.rb"
+      module TeckelOperationContractTrace
+        def self.run_operation(operation)
+          operation.call(error_input_data: "failure")
+        end
+      end
+    RUBY
+
+    specify "incorrect success" do
+      expect {
+        TeckelOperationContractTrace::OperationSuccessError.call(input_data: "ok")
+      }.to raise_error(Dry::Struct::Error) { |error|
+        expect(error.backtrace).to include /^#{Regexp.escape("operation_success_error.rb:5:in `call'")}$/
+      }
+    end
+
+    specify "incorrect success via simple return prints warning with class name, but no meaningful trace" do
+      expect {
+        TeckelOperationContractTrace::OperationSimpleSuccessError.call(input_data: "ok")
+      }.to output(
+        "[Deprecated] TeckelOperationContractTrace::OperationSimpleSuccessError#call " \
+        "Simple return values for Teckel Operations are deprecated. Use `success!` instead.\n"
+      ).to_stderr.and raise_error(Dry::Struct::Error)
+    end
+
+    specify "incorrect fail" do
+      expect {
+        TeckelOperationContractTrace::OperationFailureError.call(input_data: "ok")
+      }.to raise_error(Dry::Struct::Error) { |error|
+        expect(error.backtrace).to include /^#{Regexp.escape("operation_failure_error.rb:5:in `call'")}$/
+      }
+    end
+
+    specify "incorrect input" do
+      operation = TeckelOperationContractTrace::OperationOk
+
+      expect(operation.call(input_data: "ok")).to eq(operation.output[output_data: "all fine"])
+      expect {
+        TeckelOperationContractTrace.run_operation(operation)
+      }.to raise_error(Dry::Struct::Error) { |error|
+        expect(error.backtrace).to include /^#{Regexp.escape("operation_input_error.rb:3:in `run_operation'")}$/
+      }
+    end
+  end
+end

--- a/spec/operation/default_settings_spec.rb
+++ b/spec/operation/default_settings_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
+module TeckelOperationDefaultSettings
+  class BaseOperation
+    include ::Teckel::Operation
+
+    input none
+    output Symbol
+    error none
+
+    def call(_input)
+      success! settings.injected
+    end
+  end
+end
+
 RSpec.describe Teckel::Operation do
   context "default settings" do
-    module TeckelOperationDefaultSettings
-      class BaseOperation
-        include ::Teckel::Operation
-
-        input none
-        output Symbol
-        error none
-
-        def call(_input)
-          success! settings.injected
-        end
-      end
-    end
-
     shared_examples "operation with default settings" do |operation|
       subject { operation }
 

--- a/spec/operation/inheritance_spec.rb
+++ b/spec/operation/inheritance_spec.rb
@@ -1,57 +1,57 @@
 # frozen_string_literal: true
 
-RSpec.describe Teckel::Operation do
-  context "default settings via base class" do
-    module TeckelOperationDefaultsViaBaseClass
-      DefaultError = Struct.new(:message, :status_code)
-      Settings = Struct.new(:fail_it)
+module TeckelOperationDefaultsViaBaseClass
+  DefaultError = Struct.new(:message, :status_code)
+  Settings = Struct.new(:fail_it)
 
-      class ApplicationOperation
-        include Teckel::Operation
+  class ApplicationOperation
+    include Teckel::Operation
 
-        settings Settings
-        settings_constructor ->(data) { settings.new(*data.values_at(*settings.members)) }
+    settings Settings
+    settings_constructor ->(data) { settings.new(*data.values_at(*settings.members)) }
 
-        error DefaultError
-        error_constructor ->(data) { error.new(*data.values_at(*error.members)) }
+    error DefaultError
+    error_constructor ->(data) { error.new(*data.values_at(*error.members)) }
 
-        result!
+    result!
 
-        # Freeze the base class to make sure it's inheritable configuration is not altered
-        freeze
-      end
+    # Freeze the base class to make sure it's inheritable configuration is not altered
+    freeze
+  end
 
-      class OperationA < ApplicationOperation
-        input Struct.new(:input_data_a)
-        output Struct.new(:output_data_a)
+  class OperationA < ApplicationOperation
+    input Struct.new(:input_data_a)
+    output Struct.new(:output_data_a)
 
-        def call(input)
-          if settings&.fail_it
-            fail!(message: settings.fail_it, status_code: 400)
-          else
-            input.input_data_a * 2
-          end
-        end
-
-        finalize!
-      end
-
-      class OperationB < ApplicationOperation
-        input Struct.new(:input_data_b)
-        output Struct.new(:output_data_b)
-
-        def call(input)
-          if settings&.fail_it
-            fail!(message: settings.fail_it, status_code: 500)
-          else
-            input.input_data_b * 4
-          end
-        end
-
-        finalize!
+    def call(input)
+      if settings&.fail_it
+        fail!(message: settings.fail_it, status_code: 400)
+      else
+        success!(input.input_data_a * 2)
       end
     end
 
+    finalize!
+  end
+
+  class OperationB < ApplicationOperation
+    input Struct.new(:input_data_b)
+    output Struct.new(:output_data_b)
+
+    def call(input)
+      if settings&.fail_it
+        fail!(message: settings.fail_it, status_code: 500)
+      else
+        success!(input.input_data_b * 4)
+      end
+    end
+
+    finalize!
+  end
+end
+
+RSpec.describe Teckel::Operation do
+  context "default settings via base class" do
     let(:operation_a) { TeckelOperationDefaultsViaBaseClass::OperationA }
     let(:operation_b) { TeckelOperationDefaultsViaBaseClass::OperationB }
 

--- a/spec/operation/results_spec.rb
+++ b/spec/operation/results_spec.rb
@@ -3,27 +3,75 @@
 require 'support/dry_base'
 require 'support/fake_models'
 
-RSpec.describe Teckel::Operation do
-  context "with build in result object" do
-    class CreateUserWithResult
-      include Teckel::Operation
+class CreateUserWithResult
+  include Teckel::Operation
 
-      result!
+  result!
 
-      input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer)
-      output Types.Instance(User)
-      error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
+  input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer)
+  output Types.Instance(User)
+  error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
 
-      def call(input)
-        user = User.new(name: input[:name], age: input[:age])
-        if user.save
-          user
-        else
-          fail!(message: "Could not save User", errors: user.errors)
-        end
-      end
+  def call(input)
+    user = User.new(name: input[:name], age: input[:age])
+    if user.save
+      success! user
+    else
+      fail!(message: "Could not save User", errors: user.errors)
+    end
+  end
+end
+
+class CreateUserCustomResult
+  include Teckel::Operation
+
+  class MyResult
+    include Teckel::Result # makes sure this can be used in a Chain
+
+    def initialize(value, success, opts = {})
+      @value, @success, @opts = value, success, opts
     end
 
+    # implementing Teckel::Result
+    def successful?
+      @success
+    end
+
+    # implementing Teckel::Result
+    attr_reader :value
+
+    attr_reader :opts
+  end
+
+  result MyResult
+  result_constructor ->(value, success) { result.new(value, success, time: Time.now.to_i) }
+
+  input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer)
+  output Types.Instance(User)
+  error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
+
+  def call(input)
+    user = User.new(name: input[:name], age: input[:age])
+    if user.save
+      success! user
+    else
+      fail!(message: "Could not save User", errors: user.errors)
+    end
+  end
+end
+
+class CreateUserOverwritingResult
+  include Teckel::Operation
+
+  class Result
+    include Teckel::Result # makes sure this can be used in a Chain
+
+    def initialize(value, success); end
+  end
+end
+
+RSpec.describe Teckel::Operation do
+  context "with build in result object" do
     specify "output" do
       result = CreateUserWithResult.call(name: "Bob", age: 23)
       expect(result).to be_a(Teckel::Result)
@@ -40,44 +88,6 @@ RSpec.describe Teckel::Operation do
   end
 
   context "using custom result" do
-    class CreateUserCustomResult
-      include Teckel::Operation
-
-      class MyResult
-        include Teckel::Result # makes sure this can be used in a Chain
-
-        def initialize(value, success, opts = {})
-          @value, @success, @opts = value, success, opts
-        end
-
-        # implementing Teckel::Result
-        def successful?
-          @success
-        end
-
-        # implementing Teckel::Result
-        attr_reader :value
-
-        attr_reader :opts
-      end
-
-      result MyResult
-      result_constructor ->(value, success) { result.new(value, success, time: Time.now.to_i) }
-
-      input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer)
-      output Types.Instance(User)
-      error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
-
-      def call(input)
-        user = User.new(name: input[:name], age: input[:age])
-        if user.save
-          user
-        else
-          fail!(message: "Could not save User", errors: user.errors)
-        end
-      end
-    end
-
     specify "output" do
       result = CreateUserCustomResult.call(name: "Bob", age: 23)
       expect(result).to be_a(CreateUserCustomResult::MyResult)
@@ -98,16 +108,6 @@ RSpec.describe Teckel::Operation do
   end
 
   context "overwriting Result" do
-    class CreateUserOverwritingResult
-      include Teckel::Operation
-
-      class Result
-        include Teckel::Result # makes sure this can be used in a Chain
-
-        def initialize(value, success); end
-      end
-    end
-
     it "uses the class definition" do
       expect(CreateUserOverwritingResult.result).to_not eq(Teckel::Operation::Result)
       expect(CreateUserOverwritingResult.result).to eq(CreateUserOverwritingResult::Result)

--- a/spec/rb27/pattern_matching_spec.rb
+++ b/spec/rb27/pattern_matching_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Ruby 2.7 pattern matches for Result and Chain" do
 
       def call(usr)
         Logger.new(File::NULL).info("User #{usr.name} created")
-        usr
+        success! usr
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe "Ruby 2.7 pattern matches for Result and Chain" do
         if settings&.fail_befriend
           fail!(message: "Did not find a friend.")
         else
-          { user: user, friend: User.new(name: "A friend", age: 42) }
+          success!(user: user, friend: User.new(name: "A friend", age: 42))
         end
       end
     end

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -3,15 +3,17 @@
 require 'support/dry_base'
 require 'support/fake_models'
 
+module TeckelResultTest
+  class MissingResultImplementation
+    include Teckel::Result
+    def initialize(value, success); end
+  end
+end
+
 RSpec.describe Teckel::Result do
   describe "missing initialize" do
-    class MissingResultImplementation
-      include Teckel::Result
-      def initialize(value, success); end
-    end
-
     specify do
-      result = MissingResultImplementation["value", true]
+      result = TeckelResultTest::MissingResultImplementation["value", true]
       expect { result.successful? }.to raise_error(NotImplementedError)
       expect { result.failure? }.to raise_error(NotImplementedError)
       expect { result.value }.to raise_error(NotImplementedError)


### PR DESCRIPTION
The default throw-catch handling is now contained in the Runner class. This allows users to replace the entire runner logic.
The output and error values are now generated within the `success!` and `fail!` calls, before they are thrown. This allows for better stack traces, which now include the exact line in an Operation where an error or output contract was called with incorrect data.
Simple return values, that where considered success values, are now discarded. This allows us to enforce users to be explicit about the return value. Also, providing a meaningful trace for an incorrectly called success contract is hard with plain return values. This behavior can be changed by providing a custom Runner implementation.

- [x] Docs and specs need some work to not use implicit success results (via simple return values) any more.