### PR TITLE
instance_exec input and result constructor in Operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changes
 
-- Breaking: "Teckel::Chain" will not be required by default. require manually if needed `require "teckel/chain"`
+- Breaking: `Teckel::Chain` will not be required by default. require manually if needed `require "teckel/chain"`
+- Breaking: Internally, `Teckel::Operation::Runner` instead of `:success` and `:failure` now only uses `:halt` as it's throw-catch symbol.
+- Add: Using the default `Teckel::Operation::Runner`, `input_constructor` and `result_constructor` will be executed
+  within the context of the operation instance. This allows for `input_constructor` to call `fail!` and `success!` 
+  without ever `call`ing the operation
+
 
 ## 0.6.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem "irb", ">= 1.2.7", "< 2", platform: :mri if RUBY_VERSION >= '2.5'
   gem "dry-struct", ">= 1.1.1", "< 2"
   gem "dry-monads", ">= 1.3", "< 2"
+  gem "dry-validation", ">= 1.5.6", "< 2"
 end
 
 group :test do

--- a/_pages/docs/operations/basics.md
+++ b/_pages/docs/operations/basics.md
@@ -14,7 +14,7 @@
 ..     attr_reader :name, :age
 ..   end
 ..
-..   input_constructor ->(data) { input.new(**data) }
+..   input_constructor ->(data) { Input.new(**data) }
 ..
 ..   Output = ::User
 ..

--- a/_pages/docs/operations/input_data_validation.md
+++ b/_pages/docs/operations/input_data_validation.md
@@ -44,10 +44,10 @@ This example uses [dry-validation](https://dry-rb.org/gems/dry-validation), but 
 ..   include Teckel::Operation
 ..   result!
 .. 
-..   input CreateUserContract
+..   input CreateUserContract.new
 ..
 ..   input_constructor(->(input){
-..     result = CreateUserContract.new.call(input)
+..     result = self.class.input.call(input)
 ..     if result.success?
 ..       result.to_h
 ..     else
@@ -118,7 +118,7 @@ Errors raised in `input_constructor` need to conform to the defined `error`:
 ..   })
 .. 
 ..   output none
-..   error  Hash.schema(message: Types::String)
+..   error  Types::Hash.schema(message: Types::String)
 .. 
 ..   def call(_); end
 ..

--- a/_pages/docs/operations/input_data_validation.md
+++ b/_pages/docs/operations/input_data_validation.md
@@ -1,0 +1,130 @@
+# Input Data Validation
+
+Usually, input definitions are quite simple and raise an error if the provided data does not match. 
+How to return a meaningful error result when input data does not conform to specifications.
+
+This example uses [dry-validation](https://dry-rb.org/gems/dry-validation), but you are free on how to validate your input data.
+
+{% filter remove_code_promt %}
+```ruby
+>> require "dry/validation"
+
+>> class User
+..   def initialize(name:, age:)
+..     @name, @age = name, age
+..   end
+..   attr_reader :name, :age
+..
+..   class << self
+..     attr_accessor :has_db
+..   end
+..
+..   def save
+..     !!User.has_db
+..   end
+.. 
+..   def errors
+..     User.has_db ? nil : { database: ["not connected"] }
+..   end
+.. end
+
+>> Dry::Validation.load_extensions(:predicates_as_macros)
+.. class CreateUserContract < Dry::Validation::Contract
+..   import_predicates_as_macros
+..
+..   schema do
+..     required(:name).filled(:string)
+..     required(:age).value(:integer)
+..   end
+..
+..   rule(:age).validate(gteq?: 18)
+.. end
+.. 
+.. class CreateUser
+..   include Teckel::Operation
+..   result!
+.. 
+..   input CreateUserContract
+..
+..   input_constructor(->(input){
+..     result = CreateUserContract.new.call(input)
+..     if result.success?
+..       result.to_h
+..     else
+..       fail!(message: "Input data validation failed", errors: result.errors.to_h)
+..     end
+..   })
+.. 
+..   output Types.Instance(User)
+..   error  Types::Hash.schema(
+..     message: Types::String,
+..     errors: Types::Hash.map(Types::Symbol, Types::Array.of(Types::String))
+..   )
+.. 
+..   def call(input)
+..     user = User.new(**input)
+..     
+..     if user.save
+..       success! user
+..     else
+..       fail!(message: "Could not save User", errors: user.errors)
+..     end
+..   end
+.. 
+..   finalize!
+.. end
+```
+{% endfilter %}
+
+
+{% filter remove_code_promt %}
+```ruby
+>> User.has_db = true
+>> CreateUser.call(name: "Bob", age: 23).success
+=> #<User:<...> @name="Bob", @age=23>
+```
+{% endfilter %}
+
+Error from response from our validation in `input_constructor`:
+
+{% filter remove_code_promt %}
+```ruby
+>> CreateUser.call(name: "Bob", age: 10).failure
+=> {:message=>"Input data validation failed", :errors=>{:age=>["must be greater than or equal to 18"]}}
+```
+{% endfilter %}
+
+Error response from the our operation `call`:
+
+{% filter remove_code_promt %}
+```ruby
+>> User.has_db = false
+>> CreateUser.call(name: "Bob", age: 23).failure
+=> {:message=>"Could not save User", :errors=>{:database=>["not connected"]}}
+```
+{% endfilter %}
+
+Errors raised in `input_constructor` need to conform to the defined `error`:
+
+```ruby
+>> class IncorrectFailure
+..   include Teckel::Operation
+.. 
+..   result!
+.. 
+..   input(->(input) { input }) # pass
+..   input_constructor(->(_input) {
+..     fail!("Input data validation failed")
+..   })
+.. 
+..   output none
+..   error  Hash.schema(message: Types::String)
+.. 
+..   def call(_); end
+..
+..   finalize!
+.. end
+
+>> IncorrectFailure.call rescue $ERROR_INFO
+=> #<Dry::Types::ConstraintError:<...> "Input data validation failed" violates constraints (type?(Hash, "Input data validation failed") failed)>
+```

--- a/lib/teckel/chain/config.rb
+++ b/lib/teckel/chain/config.rb
@@ -103,13 +103,42 @@ module Teckel
       #  @example
       #    class MyOperation
       #      include Teckel::Operation
+      #      result!
+      #
+      #      settings Struct.new(:say, :other)
+      #      settings_constructor ->(data) { settings.new(*data.values_at(*settings.members)) }
+      #
+      #      input none
+      #      output Hash
+      #      error none
+      #
+      #      def call(_)
+      #        success!(settings.to_h)
+      #      end
+      #    end
+      #
+      #    class Chain
+      #      include Teckel::Chain
       #
       #      class Result < Teckel::Operation::Result
-      #        def initialize(value, success, step, options = {}); end
+      #        def initialize(value, success, step, opts = {})
+      #          super(value, success)
+      #          @step = step
+      #          @opts = opts
+      #        end
+      #
+      #        class << self
+      #          alias :[] :new # Alias the default constructor to :new
+      #        end
+      #
+      #        attr_reader :opts, :step
       #      end
       #
-      #      # If you need more control over how to build a new +Settings+ instance
-      #      result_constructor ->(value, success, step) { result.new(value, success, step, {foo: :bar}) }
+      #      result_constructor ->(value, success, step) {
+      #        result.new(value, success, step, time: Time.now.to_i)
+      #      }
+      #
+      #      step :a, MyOperation
       #    end
       def result_constructor(sym_or_proc = nil)
         constructor = build_constructor(result, sym_or_proc) unless sym_or_proc.nil?

--- a/spec/operation/fail_on_input_spec.rb
+++ b/spec/operation/fail_on_input_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "dry/validation"
+require 'support/dry_base'
+require 'support/fake_models'
+
+module TeckelOperationFailOnOInput
+  class NewUserContract < Dry::Validation::Contract
+    schema do
+      required(:name).filled(:string)
+      required(:age).value(:integer)
+    end
+  end
+
+  class CreateUser
+    include Teckel::Operation
+
+    result!
+
+    input(->(input) { input }) # NoOp
+    input_constructor(->(input){
+      result = NewUserContract.new.call(input)
+      if result.success?
+        result.to_h
+      else
+        fail!(message: "Input data validation failed", errors: [result.errors.to_h])
+      end
+    })
+
+    output Types.Instance(User)
+    error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
+
+    def call(input)
+      user = User.new(name: input[:name], age: input[:age])
+      if user.save
+        success! user
+      else
+        fail!(message: "Could not save User", errors: user.errors)
+      end
+    end
+
+    finalize!
+  end
+
+  class CreateUserIncorrectFailure
+    include Teckel::Operation
+
+    result!
+
+    input(->(input) { input }) # NoOp
+    input_constructor(->(_input) {
+      fail!("Input data validation failed")
+    })
+
+    output none
+    error  Types::Hash.schema(message: Types::String, errors: Types::Array.of(Types::Hash))
+
+    def call(_); end
+    finalize!
+  end
+end
+
+RSpec.describe Teckel::Operation do
+  specify "successs" do
+    result = TeckelOperationFailOnOInput::CreateUser.call(name: "Bob", age: 23)
+    expect(result).to be_successful
+    expect(result.success).to be_a(User)
+  end
+
+  describe "failing in input_constructor" do
+    let(:failure_input) do
+      { name: "", age: "incorrect type" }
+    end
+
+    it "returns the failure thrown in input_constructor" do
+      result = TeckelOperationFailOnOInput::CreateUser.call(failure_input)
+      expect(result).to be_a(Teckel::Operation::Result)
+      expect(result).to be_failure
+      expect(result.failure).to eq(
+        message: "Input data validation failed",
+        errors: [
+          { name: ["must be filled"], age: ["must be an integer"] }
+        ]
+      )
+    end
+
+    it "does not run .call" do
+      expect(TeckelOperationFailOnOInput::CreateUser).to receive(:new).and_wrap_original do |m, *args|
+        op_instance = m.call(*args)
+        expect(op_instance).to_not receive(:call)
+        op_instance
+      end
+
+      TeckelOperationFailOnOInput::CreateUser.call(failure_input)
+    end
+  end
+
+  specify "thrown failure needs to conform to :error" do
+    expect {
+      TeckelOperationFailOnOInput::CreateUserIncorrectFailure.call(name: "Bob", age: 23)
+    }.to raise_error(Dry::Types::ConstraintError, /violates constraints/)
+  end
+end

--- a/spec/operation/fail_on_input_spec.rb
+++ b/spec/operation/fail_on_input_spec.rb
@@ -17,9 +17,9 @@ module TeckelOperationFailOnOInput
 
     result!
 
-    input(->(input) { input }) # NoOp
+    input(NewUserContract.new)
     input_constructor(->(input){
-      result = NewUserContract.new.call(input)
+      result = self.class.input.call(input)
       if result.success?
         result.to_h
       else

--- a/spec/operation/result_spec.rb
+++ b/spec/operation/result_spec.rb
@@ -3,25 +3,46 @@
 RSpec.describe Teckel::Operation::Result do
   let(:failure_value) { "some error" }
   let(:failed_result) { Teckel::Operation::Result.new(failure_value, false) }
+  let(:failed_nil_result) { Teckel::Operation::Result.new(failure_value, nil) }
 
-  let(:success_value) { "some error" }
-  let(:successful_result) { Teckel::Operation::Result.new(failure_value, true) }
+  let(:success_value) { "some success" }
+  let(:successful_result) { Teckel::Operation::Result.new(success_value, true) }
+  let(:successful_1_result) { Teckel::Operation::Result.new(success_value, 1) }
 
-  it { expect(successful_result.successful?).to be(true) }
-  it { expect(failed_result.successful?).to be(false) }
+  it { expect(successful_result.successful?).to eq(true) }
+  it { expect(successful_1_result.successful?).to eq(true) }
+  it { expect(failed_result.successful?).to eq(false) }
+  it { expect(failed_nil_result.successful?).to eq(false) }
 
-  it { expect(successful_result.failure?).to be(false) }
-  it { expect(failed_result.failure?).to be(true) }
+  it { expect(successful_result.failure?).to eq(false) }
+  it { expect(successful_1_result.failure?).to eq(false) }
+  it { expect(failed_result.failure?).to eq(true) }
+  it { expect(failed_nil_result.failure?).to eq(true) }
 
   it { expect(successful_result.value).to eq(success_value) }
   it { expect(failed_result.value).to eq(failure_value) }
 
   describe "#success" do
-    it { expect(successful_result.success).to eq(success_value) }
+    it("on successful result, returns value") {
+      expect(successful_result.success).to eq(success_value)
+    }
 
-    it { expect(failed_result.success).to eq(nil) }
-    it { expect(failed_result.success("other")).to eq("other") }
-    it { expect(failed_result.success { |value| "Failed: #{value}" } ).to eq("Failed: some error") }
+    describe "on failed result" do
+      it("with no fallbacks, returns nil") {
+        expect(failed_result.success).to eq(nil)
+      }
+      it("with default-argument, returns default-argument") {
+        expect(failed_result.success("other")).to eq("other")
+      }
+      it("with block, returns block return value") {
+        expect(failed_result.success { |value| "Failed: #{value}" } ).to eq("Failed: some error")
+      }
+      it("with default-argument and block given, returns default-argument, skips block") {
+        expect { |blk|
+          expect(failed_result.success("default", &blk)).to_not eq("default")
+        }.to(yield_control)
+      }
+    end
   end
 
   describe "#failure" do
@@ -29,6 +50,6 @@ RSpec.describe Teckel::Operation::Result do
 
     it { expect(successful_result.failure).to eq(nil) }
     it { expect(successful_result.failure("other")).to eq("other") }
-    it { expect(successful_result.failure { |value| "Failed: #{value}" } ).to eq("Failed: some error") }
+    it { expect(successful_result.failure { |value| "Failed: #{value}" } ).to eq("Failed: some success") }
   end
 end

--- a/spec/operation/results_spec.rb
+++ b/spec/operation/results_spec.rb
@@ -44,7 +44,7 @@ class CreateUserCustomResult
   end
 
   result MyResult
-  result_constructor ->(value, success) { result.new(value, success, time: Time.now.to_i) }
+  result_constructor ->(value, success) { MyResult.new(value, success, time: Time.now.to_i) }
 
   input  Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer)
   output Types.Instance(User)

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -101,7 +101,7 @@ module TeckelOperationKeywordContracts
       attr_reader :name, :age
     end
 
-    input_constructor ->(data) { input.new(**data) }
+    input_constructor ->(data) { Input.new(**data) }
 
     Output = ::User
 
@@ -129,7 +129,7 @@ module TeckelOperationCreateUserSplatInit
     include Teckel::Operation
 
     input Struct.new(:name, :age)
-    input_constructor ->(data) { input.new(*data) }
+    input_constructor ->(data) { self.class.input.new(*data) }
 
     Output = ::User
 
@@ -346,7 +346,7 @@ RSpec.describe Teckel::Operation do
 
       expect {
         op.with(more: :stuff_2)
-      }.to raise_error(Teckel::Error)
+      }.to raise_error(Teckel::Error, "Operation already has settings assigned.")
     end
   end
 

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -12,11 +12,11 @@ end
 
 RSpec.describe Teckel::Result do
   describe "missing initialize" do
-    specify do
+    specify "raises NotImplementedError" do
       result = TeckelResultTest::MissingResultImplementation["value", true]
-      expect { result.successful? }.to raise_error(NotImplementedError)
-      expect { result.failure? }.to raise_error(NotImplementedError)
-      expect { result.value }.to raise_error(NotImplementedError)
+      expect { result.successful? }.to raise_error(NotImplementedError, "Result object does not implement `successful?`")
+      expect { result.failure? }.to raise_error(NotImplementedError, "Result object does not implement `successful?`")
+      expect { result.value }.to raise_error(NotImplementedError, "Result object does not implement `value`")
     end
   end
 end


### PR DESCRIPTION
This allows the generation of the Input data to fail the Operation early (see `_pages/docs/operations/input_data_validation.md`), access `settings` etc.

The result constructor can now include the operation instance into the result object, which allows to integrate custom solutions for rollback, error reporting etc.