### PR TITLE
Add mutantion testing

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -82,6 +82,8 @@ jobs:
         ruby: ["2.6", "2.7", "3.0"]
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -70,3 +70,25 @@ jobs:
         echo "branch: $GIT_BRANCH"
         echo "date: $GIT_COMMITTED_AT"
         ./tmp/cc-test-reporter after-build -t simplecov
+
+  mutant:
+    name: Mutant
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0"]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{matrix.ruby}}
+        bundler-cache: true
+    - name: Bundle install
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3 --without tools docs benchmarks
+    - run: bundle exec mutant run --since HEAD~1 --zombie

--- a/.mutant.yml
+++ b/.mutant.yml
@@ -1,0 +1,8 @@
+---
+mutation_timeout: 1.0
+integration: rspec
+includes:
+  - lib
+requires:
+  - teckel
+  - teckel/chain

--- a/.mutant.yml
+++ b/.mutant.yml
@@ -6,3 +6,6 @@ includes:
 requires:
   - teckel
   - teckel/chain
+matcher:
+  subjects:
+  - 'Teckel*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,6 @@ Metrics/BlockLength:
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
+
+Gemspec/OrderedDependencies:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,19 +4,30 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: 2.4
+  SuggestExtensions: false
+  NewCops: enable
   Exclude:
     - spec/rb27/*
 
 Bundler/OrderedGems:
   Enabled: false
 
-Metrics/BlockLength:
-  Exclude:
-    - teckel.gemspec
-    - spec/**/*_spec.rb
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: start_of_line
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
-Gemspec/OrderedDependencies:
-  Enabled: false
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Metrics/BlockLength:
+  Exclude:
+    - teckel.gemspec
+    - spec/**/*_spec.rb

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,17 @@
 
 ## Roadmap
 
-- Refactor tests/code with Mutation testing on branch [`feature/mutant`](https://github.com/fnordfish/teckel/tree/feature/mutant)
+- ...
+
+## Testing
+
+- Default specs: `bundle exec rake spec`
+- Testing yard doc sample: `bundle exec rake docs:yard:doctest`
+- Running mutation tests: `bundle exec mutant run -- 'Teckel::Operation*'`
+  * https://github.com/mbj/mutant/blob/master/docs/mutant-rspec.md
+  * https://github.com/mbj/mutant/blob/master/docs/incremental.md
+
+>>>>>>> 9041466 (Add mutant)
 
 ## Building docs
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@
 
 ## Roadmap
 
-- Add mutations tests to CI
+- Get those uncovered mutations down (add/refactor tests, and/or refactor code)
 - Add helpers for testing frameworks rspec and minitest. Something along the lines of:
   `expect_teckel_opertaion(MyOperation, with: {some: :settings}).to be_called(some: :params).and_return(SomeReturnObject)`
 
@@ -14,7 +14,8 @@
 
 - Default specs: `bundle exec rake spec`
 - Testing yard doc sample: `bundle exec rake docs:yard:doctest`
-- Running mutation tests: `bundle exec mutant run -- 'Teckel::Operation*'`
+- Running mutation tests: `bundle exec mutant run -- 'Teckel*'`
+  * Limit scopes like `bundle exec mutant run -- 'Teckel::Operation::Result*'`` 
   * https://github.com/mbj/mutant/blob/master/docs/mutant-rspec.md
   * https://github.com/mbj/mutant/blob/master/docs/incremental.md
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,6 +7,8 @@
 ## Roadmap
 
 - Add mutations tests to CI
+- Add helpers for testing frameworks rspec and minitest. Something along the lines of:
+  `expect_teckel_opertaion(MyOperation, with: {some: :settings}).to be_called(some: :params).and_return(SomeReturnObject)`
 
 ## Testing
 
@@ -15,8 +17,6 @@
 - Running mutation tests: `bundle exec mutant run -- 'Teckel::Operation*'`
   * https://github.com/mbj/mutant/blob/master/docs/mutant-rspec.md
   * https://github.com/mbj/mutant/blob/master/docs/incremental.md
-
->>>>>>> 9041466 (Add mutant)
 
 ## Building docs
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@
 
 ## Roadmap
 
-- ...
+- Add mutations tests to CI
 
 ## Testing
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,10 @@ group :development, :test do
   gem "dry-struct", ">= 1.1.1", "< 2"
   gem "dry-monads", ">= 1.3", "< 2"
   gem "dry-validation", ">= 1.5.6", "< 2"
+
+  source 'https://oss:vGh00LMdwYktjajyXGfRsSOcynuQi92M@gem.mutant.dev' do
+    gem 'mutant-license'
+  end
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,11 @@ namespace :docs do
   end
 end
 
+desc "Test example code in user-docs (aka pages)"
+task :byexample do
+  system "#{__dir__}/bin/byexample"
+end
+
 task :default do
   Rake::Task["spec"].invoke
   Rake::Task["docs:yard:doctest"].invoke

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,8 @@ require "yard"
 require "yard/doctest/rake"
 
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.exclude_pattern = "spec/rb27/*" if RUBY_VERSION < '2.7.0'
+  # TruffleRuby 21.2.0 reports as "like ruby 2.7.3" but does not support pattern matching
+  t.exclude_pattern = "spec/rb27/*" if RUBY_VERSION < '2.7.0' || RUBY_ENGINE == "truffleruby"
 end
 
 task :docs do

--- a/_pages/docs/chains/basics.md
+++ b/_pages/docs/chains/basics.md
@@ -81,14 +81,13 @@ Defining a simple Chain with three steps.
 .. end
 
 >> result = MyChain.call(name: "Bob", age: 23)
->> result
 => #<Teckel::Chain::Result:<...>>
 
 >> result.success[:user]
-=> #<User:<...> @name="Bob", @age=23>
+=> #<User:<...> @age=23, @name="Bob">
    
 >> result.success[:friend]
-=> #<User:<...> @name="A friend", @age=42>
+=> #<User:<...> @age=42, @name="A friend">
 
 >> failure_result = MyChain.with(befriend: :fail).call(name: "Bob", age: 23)
 >> failure_result
@@ -121,7 +120,9 @@ Hash style:
 .. end
 
 >> result
-=> ["Success result", {:user=>#<User:<...> @name="Bob", @age=23>, :friend=>#<User:<...> @name="A friend", @age=42>}]
+=> ["Success result",
+  {:friend=>#<User:<...> @age=42, @name="A friend">,
+   :user=>#<User:<...> @age=23, @name="Bob">}]
 ```
 {% endfilter %}
 

--- a/_pages/docs/operations/basics.md
+++ b/_pages/docs/operations/basics.md
@@ -44,7 +44,7 @@ A Successful call:
 {% filter remove_code_promt %}
 ```ruby
 >> CreateUserInline.call(name: "Bob", age: 23)
-=> #<User:<...> @name="Bob", @age=23>
+=> #<User:<...> @age=23, @name="Bob">
 ```
 {% endfilter %}
 
@@ -53,7 +53,9 @@ A failure call:
 {% filter remove_code_promt %}
 ```ruby
 >> CreateUserInline.call(name: "Bob", age: 10)
-=> #<CreateUserInline::Error:<...> @message="Could not save User", @errors=[{:age=>"underage"}]>
+=> #<CreateUserInline::Error:<...>
+   @errors=[{:age=>"underage"}],
+   @message="Could not save User">
 ```
 {% endfilter %}
 
@@ -99,7 +101,7 @@ A Successful call:
 {% filter remove_code_promt %}
 ```ruby
 >> CreateUserDry.call(name: "Bob", age: 23)
-=> #<User:<...> @name="Bob", @age=23>
+=> #<User:<...> @age=23, @name="Bob">
 ```
 {% endfilter %}
 
@@ -108,7 +110,7 @@ A failure call:
 {% filter remove_code_promt %}
 ```ruby
 >> CreateUserDry.call(name: "Bob", age: 10)
-=> {:message=>"Could not save User", :errors=>[{:age=>"underage"}]}
+=> {:errors=>[{:age=>"underage"}], :message=>"Could not save User"}
 ```
 {% endfilter %}
 
@@ -126,7 +128,7 @@ If your contracts support Feed an instance of the input class directly to call:
 {% filter remove_code_promt %}
 ```ruby
 >> CreateUserDry.call(CreateUserDry.input[name: "Bob", age: 23])
-=> #<User:<...> @name="Bob", @age=23>
+=> #<User:<...> @age=23, @name="Bob">
 ```
 {% endfilter %}
 
@@ -254,7 +256,7 @@ Hash style:
 .. end
 
 >> result
-=> ["Success result", #<User:<...> @name="Bob", @age=23>]
+=> ["Success result", #<User:<...> @age=23, @name="Bob">]
 ```
 {% endfilter %}
 
@@ -270,6 +272,6 @@ Array style:
 .. end
 
 >> result
-=> ["Failed", {:message=>"Could not save User", :errors=>[{:age=>"underage"}]}]
+=> ["Failed", {:errors=>[{:age=>"underage"}], :message=>"Could not save User"}]
 ```
 {% endfilter %}

--- a/_pages/docs/operations/input_data_validation.md
+++ b/_pages/docs/operations/input_data_validation.md
@@ -81,7 +81,7 @@ This example uses [dry-validation](https://dry-rb.org/gems/dry-validation), but 
 ```ruby
 >> User.has_db = true
 >> CreateUser.call(name: "Bob", age: 23).success
-=> #<User:<...> @name="Bob", @age=23>
+=> #<User:<...> @age=23, @name="Bob">
 ```
 {% endfilter %}
 
@@ -90,7 +90,8 @@ Error from response from our validation in `input_constructor`:
 {% filter remove_code_promt %}
 ```ruby
 >> CreateUser.call(name: "Bob", age: 10).failure
-=> {:message=>"Input data validation failed", :errors=>{:age=>["must be greater than or equal to 18"]}}
+=> {:errors=>{:age=>["must be greater than or equal to 18"]},
+    :message=>"Input data validation failed"}
 ```
 {% endfilter %}
 
@@ -100,7 +101,7 @@ Error response from the our operation `call`:
 ```ruby
 >> User.has_db = false
 >> CreateUser.call(name: "Bob", age: 23).failure
-=> {:message=>"Could not save User", :errors=>{:database=>["not connected"]}}
+=> {:errors=>{:database=>["not connected"]}, :message=>"Could not save User"}
 ```
 {% endfilter %}
 

--- a/_pages/docs/operations/result_objects.md
+++ b/_pages/docs/operations/result_objects.md
@@ -43,7 +43,7 @@ A success call:
 => false
 
 >> result.success
-=> #<User:<...> @name="Bob", @age=23>
+=> #<User:<...> @age=23, @name="Bob">
 ```
 {% endfilter %}
 
@@ -62,7 +62,7 @@ A failure call:
 => true
 
 >> result.failure
-=> {:message=>"Could not save User", :errors=>[{:age=>"underage"}]}
+=> {:errors=>[{:age=>"underage"}], :message=>"Could not save User"}
 
 >> result.success do |value|
 ..   # do something with the error value
@@ -126,7 +126,10 @@ If you plan using your operation in a `Chain`, the should implement the interfac
 
 >> result = CreateUserOtherResult.call(name: "Bob", age: 23)
 >> result
-=> #<MyResult:<...> @value=#<User:<...>>, @success=true, @opts={:at=><time>}>
+=> #<MyResult:<...>
+  @opts={:at=><time>}, 
+  @success=true,
+  @value=#<User:<...>>
 
 >> result.at
 => <time>
@@ -138,7 +141,7 @@ If you plan using your operation in a `Chain`, the should implement the interfac
 => false
 
 >> result.value
-=> #<User:<...> @name="Bob", @age=23>
+=> #<User:<...> @age=23, @name="Bob">
 ```
 {% endfilter %}
 

--- a/_pages/requirements.txt
+++ b/_pages/requirements.txt
@@ -1,4 +1,4 @@
-byexample
+byexample>=10.0.4
 mkdocs
 mkdocs-macros-plugin
 mkdocs-material

--- a/bin/byexample
+++ b/bin/byexample
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 
-if ! (ruby --version | grep -q '^ruby 2.7.'); then
-	echo "Because of irb and ruby shenanigans, we need ruby 2.7"
+if ! (ruby -rrubygems -e 'exit Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")'); then
+	echo "Some docs are written using ruby 2.7 features."
 	exit 1
 fi
 
-irb_opts="-f --nomultiline --nocolorize"
+irb_opts="-f --nomultiline --nocolorize --noreadline --echo-on-assignment"
 irb_r="-r bundler/setup"
 irb_r+=" -r ./_pages/docs/docs_base.rb"
 irb_r+=" -r teckel"
 
+set -eux
+
 byexample -l ruby \
---options="-ruby-pretty-print" \
--x-shebang "ruby:%e %p ${irb_opts} %a ${irb_r}" $@ \
-$(ruby -e 'puts Dir["_pages/**/*.{rb,md}"]')
+--options="+ruby-pretty-print +ruby-start-large-output-in-new-line +norm-ws +tags +enhance-diff" \
+-x-shebang "ruby:%e bundle exec %p ${irb_opts} %a ${irb_r}" \
+$@ \
+'_pages/**/*.md' '_pages/**/*.rb'

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -10,7 +10,8 @@ require 'bundler'
 Bundler.settings.temporary(frozen: false) do
   gemfile do
     source 'https://rubygems.org'
-    gem 'rubocop', '~> 1.0.0'
+    ruby ">= 2.4"
+    gem 'rubocop', '~> 1.12.1'
   end
 end
 

--- a/lib/teckel/chain.rb
+++ b/lib/teckel/chain.rb
@@ -74,8 +74,10 @@ module Teckel
     end
 
     def self.included(receiver)
-      receiver.extend Config
-      receiver.extend ClassMethods
+      receiver.class_eval do
+        extend Config
+        extend ClassMethods
+      end
     end
   end
 end

--- a/lib/teckel/chain/config.rb
+++ b/lib/teckel/chain/config.rb
@@ -148,7 +148,7 @@ module Teckel
         } || raise(MissingConfigError, "Missing result_constructor config for #{self}")
       end
 
-      # Declare default settings operation iin this chain should use when called without
+      # Declare default settings operation in this chain should use when called without
       # {Teckel::Chain::ClassMethods#with #with}.
       #
       # Explicit call-time settings will *not* get merged with declared default setting.
@@ -243,9 +243,19 @@ module Teckel
         end
       end
 
+      # Prevents further modifications to this chain and its config
+      #
+      # @return [self]
+      # @!visibility public
+      def freeze
+        steps.freeze
+        @config.freeze
+        super()
+      end
+
       # @!visibility private
       def inherited(subclass)
-        super dup_config(subclass)
+        super(dup_config(subclass))
       end
 
       # @!visibility private

--- a/lib/teckel/chain/config.rb
+++ b/lib/teckel/chain/config.rb
@@ -227,7 +227,7 @@ module Teckel
       # @return [self]
       # @!visibility public
       def dup
-        dup_config(super)
+        dup_config(super())
       end
 
       # Produces a clone of this chain.
@@ -237,9 +237,9 @@ module Teckel
       # @!visibility public
       def clone
         if frozen?
-          super
+          super()
         else
-          dup_config(super)
+          dup_config(super())
         end
       end
 
@@ -264,10 +264,11 @@ module Teckel
       end
 
       def build_constructor(on, sym_or_proc)
-        if sym_or_proc.is_a?(Symbol) && on.respond_to?(sym_or_proc)
-          on.public_method(sym_or_proc)
-        elsif sym_or_proc.respond_to?(:call)
+        case sym_or_proc
+        when Proc
           sym_or_proc
+        when Symbol
+          on.public_method(sym_or_proc) if on.respond_to?(sym_or_proc)
         end
       end
     end

--- a/lib/teckel/chain/runner.rb
+++ b/lib/teckel/chain/runner.rb
@@ -29,7 +29,7 @@ module Teckel
       end
 
       def steps
-        settings == UNDEFINED ? chain.steps : steps_with_settings
+        settings.eql?(UNDEFINED) ? chain.steps : steps_with_settings
       end
 
       private

--- a/lib/teckel/config.rb
+++ b/lib/teckel/config.rb
@@ -35,12 +35,12 @@ module Teckel
     # @!visibility private
     def freeze
       @config.freeze
-      super
+      super()
     end
 
     # @!visibility private
     def dup
-      super.tap do |copy|
+      super().tap do |copy|
         copy.instance_variable_set(:@config, @config.dup)
       end
     end

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -187,9 +187,11 @@ module Teckel
     end
 
     def self.included(receiver)
-      receiver.extend         Config
-      receiver.extend         ClassMethods
-      receiver.send :include, InstanceMethods
+      receiver.class_eval do
+        extend  Config
+        extend  ClassMethods
+        include InstanceMethods
+      end
     end
   end
 end

--- a/lib/teckel/operation.rb
+++ b/lib/teckel/operation.rb
@@ -66,8 +66,6 @@ module Teckel
       #   {Teckel::Operation::Config#output output} class
       # @!visibility public
       def call(input = nil)
-        default_settings = self.default_settings
-
         if default_settings
           runner.new(self, default_settings.call)
         else
@@ -145,7 +143,7 @@ module Teckel
       #
       #   MyOperation.call #=> nil
       def none
-        Teckel::Contracts::None
+        Contracts::None
       end
     end
 

--- a/lib/teckel/operation/config.rb
+++ b/lib/teckel/operation/config.rb
@@ -217,8 +217,8 @@ module Teckel
       #   (Like calling +MyOperation.with(arg1, arg2, ...)+)
       def default_settings!(*args)
         callable = if args.size.equal?(1)
-            build_constructor(settings, args.first)
-          end
+          build_constructor(settings, args.first)
+        end
 
         callable ||= -> { settings_constructor.call(*args) }
 

--- a/lib/teckel/operation/config.rb
+++ b/lib/teckel/operation/config.rb
@@ -334,9 +334,7 @@ module Teckel
       # @return [self]
       # @!visibility public
       def dup
-        super().tap do |copy|
-          copy.instance_variable_set(:@config, @config.dup)
-        end
+        dup_config(super())
       end
 
       # Produces a clone of this operation and all it's configuration
@@ -347,16 +345,22 @@ module Teckel
         if frozen?
           super()
         else
-          super().tap do |copy|
-            copy.instance_variable_set(:@config, @config.dup)
-          end
+          dup_config(super())
         end
+      end
+
+      # Prevents further modifications to this operation and its config
+      #
+      # @return [self]
+      # @!visibility public
+      def freeze
+        @config.freeze
+        super()
       end
 
       # @!visibility private
       def inherited(subclass)
-        subclass.instance_variable_set(:@config, @config.dup)
-        super(subclass)
+        super(dup_config(subclass))
       end
 
       # @!visibility private
@@ -369,6 +373,11 @@ module Teckel
       end
 
       private
+
+      def dup_config(other_class)
+        other_class.instance_variable_set(:@config, @config.dup)
+        other_class
+      end
 
       def get_set_constructor(name, on, sym_or_proc)
         constructor = build_constructor(on, sym_or_proc)

--- a/lib/teckel/operation/result.rb
+++ b/lib/teckel/operation/result.rb
@@ -38,16 +38,16 @@ module Teckel
       include Teckel::Result
 
       # @param value [Object] The result value
-      # @param success [Boolean] whether this is a successful result
-      def initialize(value, success)
+      # @param successful [Boolean] whether this is a successful result
+      def initialize(value, successful)
         @value = value
-        @success = (!!success).freeze
+        @successful = successful
       end
 
       # Whether this is a success result
       # @return [Boolean]
       def successful?
-        @success
+        @successful
       end
 
       # @!attribute [r] value
@@ -59,8 +59,8 @@ module Teckel
       # @param  default [Mixed] return this default value if it's not a failure result
       # @return [Mixed] the value/payload
       def failure(default = nil, &block)
-        return @value unless @success
-        return yield(@value) if block
+        return value unless @successful
+        return yield(value) if block
 
         default
       end
@@ -70,8 +70,8 @@ module Teckel
       # @param  default [Mixed] return this default value if it's not a success result
       # @return [Mixed] the value/payload
       def success(default = nil, &block)
-        return @value if @success
-        return yield(@value) if block
+        return value if @successful
+        return yield(value) if block
 
         default
       end

--- a/lib/teckel/operation/runner.rb
+++ b/lib/teckel/operation/runner.rb
@@ -37,7 +37,7 @@ module Teckel
       # This is just here to raise a meaningful error.
       # @!visibility private
       def with(*)
-        raise Teckel::Error, "Operation already has settings assigned."
+        raise Error, "Operation already has settings assigned."
       end
 
       # Halt any further execution with a output value
@@ -46,7 +46,7 @@ module Teckel
       # @!visibility protected
       def success!(*args)
         value =
-          if args.size == 1 && operation.output === args.first # rubocop:disable Style/CaseEquality
+          if args.size.equal?(1) && operation.output === args.first # rubocop:disable Style/CaseEquality
             args.first
           else
             operation.output_constructor.call(*args)
@@ -61,7 +61,7 @@ module Teckel
       # @!visibility protected
       def fail!(*args)
         value =
-          if args.size == 1 && operation.error === args.first # rubocop:disable Style/CaseEquality
+          if args.size.equal?(1) && operation.error === args.first # rubocop:disable Style/CaseEquality
             args.first
           else
             operation.error_constructor.call(*args)

--- a/lib/teckel/operation/runner.rb
+++ b/lib/teckel/operation/runner.rb
@@ -29,7 +29,7 @@ module Teckel
 
         op = operation.new
         op.runner = self
-        op.settings = settings if settings != UNDEFINED
+        op.settings = settings unless settings.eql?(UNDEFINED)
 
         @instance = op
       end

--- a/lib/teckel/result.rb
+++ b/lib/teckel/result.rb
@@ -55,8 +55,10 @@ module Teckel
     end
 
     def self.included(receiver)
-      receiver.extend         ClassMethods
-      receiver.send :include, InstanceMethods
+      receiver.class_eval do
+        extend  ClassMethods
+        include InstanceMethods
+      end
     end
   end
 end

--- a/spec/chain_spec.rb
+++ b/spec/chain_spec.rb
@@ -67,6 +67,11 @@ module TeckelChainTest
 end
 
 RSpec.describe Teckel::Chain do
+  let(:frozen_error) do
+    # different ruby versions raise different errors
+    defined?(FrozenError) ? FrozenError : RuntimeError
+  end
+
   it 'Chain input points to first step input' do
     expect(TeckelChainTest::Chain.input).to eq(TeckelChainTest::CreateUser.input)
   end
@@ -118,11 +123,6 @@ RSpec.describe Teckel::Chain do
   end
 
   describe "#finalize!" do
-    let(:frozen_error) do
-      # different ruby versions raise different errors
-      defined?(FrozenError) ? FrozenError : RuntimeError
-    end
-
     subject { TeckelChainTest::Chain.dup }
 
     it "freezes the Chain class and operation classes" do
@@ -172,6 +172,84 @@ RSpec.describe Teckel::Chain do
 
       allow(subject).to receive(:call) { :mocked }
       expect(subject.call).to eq(:mocked)
+    end
+  end
+
+  describe "#clone" do
+    subject { TeckelChainTest::Chain.dup }
+    let(:klone) { subject.clone }
+
+    it 'clones' do
+      expect(klone.object_id).not_to be_eql(subject.object_id)
+    end
+
+    it 'clones config' do
+      orig_config = subject.instance_variable_get(:@config)
+      klone_config = klone.instance_variable_get(:@config)
+      expect(klone_config.object_id).not_to be_eql(orig_config.object_id)
+    end
+
+    it 'clones steps' do
+      orig_settings = subject.instance_variable_get(:@config).instance_variable_get(:@config)[:steps]
+      klone_settings = klone.instance_variable_get(:@config).instance_variable_get(:@config)[:steps]
+
+      expect(orig_settings).to be_a(Array)
+      expect(klone_settings).to be_a(Array)
+      expect(klone_settings.object_id).not_to be_eql(orig_settings.object_id)
+    end
+  end
+
+  describe "frozen" do
+    subject { TeckelChainTest::Chain.dup }
+
+    it "also freezes the config" do
+      expect { subject.freeze }.to change {
+        [
+          subject.frozen?,
+          subject.instance_variable_get(:@config).frozen?
+        ]
+      }.from([false, false]).to([true, true])
+    end
+
+    it "prevents changes to steps" do
+      subject.freeze
+      expect {
+        subject.class_eval do
+          step :yet_other, TeckelChainTest::AddFriend
+        end
+      }.to raise_error(frozen_error)
+    end
+
+    it "prevents changes to config" do
+      subject.freeze
+      expect {
+        subject.class_eval do
+          default_settings!(a: { say: "Chain Default" })
+        end
+      }.to raise_error(frozen_error)
+    end
+
+    describe '#clone' do
+      subject { TeckelChainTest::Chain.dup }
+
+      it 'clones the class' do
+        subject.freeze
+        klone = subject.clone
+
+        expect(klone).to be_frozen
+        expect(klone.object_id).not_to be_eql(subject.object_id)
+      end
+
+      it 'cloned class uses the same, frozen config' do
+        subject.freeze
+        klone = subject.clone
+
+        orig_config = subject.instance_variable_get(:@config)
+        klone_config = klone.instance_variable_get(:@config)
+
+        expect(klone_config).to be_frozen
+        expect(klone_config.object_id).to be_eql(orig_config.object_id)
+      end
     end
   end
 end

--- a/spec/chain_spec.rb
+++ b/spec/chain_spec.rb
@@ -85,8 +85,7 @@ RSpec.describe Teckel::Chain do
 
   context "success" do
     it "result matches" do
-      result =
-        TeckelChainTest::Chain.
+      result = TeckelChainTest::Chain.
         with(befriend: nil).
         call(name: "Bob", age: 23)
 
@@ -96,8 +95,7 @@ RSpec.describe Teckel::Chain do
 
   context "failure" do
     it "returns a Result for invalid input" do
-      result =
-        TeckelChainTest::Chain.
+      result = TeckelChainTest::Chain.
         with(befriend: :fail).
         call(name: "Bob", age: 0)
 
@@ -108,8 +106,7 @@ RSpec.describe Teckel::Chain do
     end
 
     it "returns a Result for failed step" do
-      result =
-        TeckelChainTest::Chain.
+      result = TeckelChainTest::Chain.
         with(befriend: :fail).
         call(name: "Bob", age: 23)
 

--- a/spec/operation/config_spec.rb
+++ b/spec/operation/config_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require "ostruct"
+
+RSpec.describe Teckel::Operation do
+  let(:operation) do
+    Class.new do
+      include Teckel::Operation
+      input none
+      output ->(o) { o }
+      error none
+
+      def call(_)
+        success! settings
+      end
+    end
+  end
+
+  let(:blank_operation) do
+    Class.new do
+      include Teckel::Operation
+    end
+  end
+
+  describe ".settings" do
+    specify "no settings" do
+      expect(operation.settings).to eq(Teckel::Contracts::None)
+      expect(operation.settings_constructor).to eq(Teckel::Contracts::None.method(:new))
+    end
+
+    specify "with settings klass" do
+      settings_klass = Struct.new(:name)
+      operation.settings(settings_klass)
+      expect(operation.settings).to eq(settings_klass)
+    end
+
+    specify "without settings class, with settings constructor as proc" do
+      settings_const = ->(sets) { sets.to_h { |k, v| [k.to_s, v.to_i] } }
+      operation.settings_constructor(settings_const)
+
+      expect(operation.settings).to eq(Teckel::Contracts::None)
+      expect(operation.settings_constructor).to eq(settings_const)
+
+      runner = operation.with(key: "1")
+      expect(runner).to be_a(Teckel::Operation::Runner)
+      expect(runner.settings).to eq({ "key" => 1 })
+    end
+
+    specify "with settings class, with settings constructor as symbol" do
+      settings_klass = Struct.new(:name) do
+        def self.make_one(opts)
+          new(opts[:name])
+        end
+      end
+
+      operation.settings(settings_klass)
+      operation.settings_constructor(:make_one)
+
+      expect(operation.settings).to eq(settings_klass)
+      expect(operation.settings_constructor).to eq(settings_klass.method(:make_one))
+
+      runner = operation.with(name: "value")
+      expect(runner).to be_a(Teckel::Operation::Runner)
+      expect(runner.settings).to be_a(settings_klass)
+      expect(runner.settings.name).to eq("value")
+    end
+
+    specify "with settings class as constant" do
+      settings_klass = Struct.new(:name)
+      operation.const_set(:Settings, settings_klass)
+
+      expect(operation.settings).to eq(settings_klass)
+      expect(operation.settings_constructor).to eq(settings_klass.method(:[]))
+    end
+  end
+
+  describe ".default_settings" do
+    specify "no default_settings" do
+      expect(operation.default_settings).to be_nil
+      expect(operation.runner).to receive(:new).with(operation).and_call_original
+
+      operation.call
+    end
+
+    specify "default_settings!() with no default_settings" do
+      operation.default_settings!
+      expect(operation.default_settings).to be_a(Proc)
+
+      expect(operation.default_settings).to receive(:call).with(no_args).and_wrap_original do |original_method, *args, &block|
+        settings = original_method.call(*args, &block)
+        expect(settings).to be_nil
+        expect(operation.runner).to receive(:new).with(operation, settings).and_call_original
+        settings
+      end
+
+      operation.call
+    end
+
+    specify "default_settings!() with default_settings" do
+      settings_klass = Struct.new(:name)
+
+      operation.settings(settings_klass)
+      operation.default_settings!
+
+      expect(operation.default_settings).to be_a(Proc)
+
+      expect(operation.default_settings).to receive(:call).with(no_args).and_wrap_original do |original_method, *args, &block|
+        settings = original_method.call(*args, &block)
+        expect(settings).to be_a(settings_klass).and have_attributes(name: nil)
+        expect(operation.runner).to receive(:new).with(operation, settings).and_call_original
+        settings
+      end
+
+      operation.call
+    end
+
+    specify "default_settings!(arg) with default_settings" do
+      settings_klass = Struct.new(:name)
+
+      operation.settings(settings_klass)
+      operation.default_settings!("Bob")
+
+      expect(operation.default_settings).to be_a(Proc)
+
+      expect(operation.default_settings).to receive(:call).with(no_args).and_wrap_original do |original_method, *args, &block|
+        settings = original_method.call(*args, &block)
+        expect(settings).to be_a(settings_klass).and have_attributes(name: "Bob")
+        expect(operation.runner).to receive(:new).with(operation, settings).and_call_original
+        settings
+      end
+
+      expect(operation.call).to be_a(Struct).and have_attributes(name: "Bob")
+    end
+  end
+
+  %i[input output error].each do |meth|
+    describe ".#{meth}" do
+      specify "missing .#{meth} config raises MissingConfigError" do
+        expect {
+          blank_operation.public_send(meth)
+        }.to raise_error(Teckel::MissingConfigError, "Missing #{meth} config for #{blank_operation}")
+      end
+    end
+
+    describe ".#{meth}_constructor" do
+      specify "missing .#{meth}_constructor config raises MissingConfigError for missing #{meth}" do
+        expect {
+          blank_operation.public_send(:"#{meth}_constructor")
+        }.to raise_error(Teckel::MissingConfigError, "Missing #{meth} config for #{blank_operation}")
+      end
+    end
+  end
+
+  specify "default settings config" do
+    expect(blank_operation.settings).to eq(Teckel::Contracts::None)
+  end
+
+  specify "default settings_constructor" do
+    expect(blank_operation.settings_constructor).to eq(Teckel::Contracts::None.method(:[]))
+  end
+
+  specify "default settings_constructor with settings config set" do
+    settings_klass = Struct.new(:name)
+    blank_operation.settings(settings_klass)
+
+    expect(blank_operation.settings_constructor).to eq(settings_klass.method(:[]))
+  end
+
+  specify "unsupported constructor method" do
+    blank_operation.settings(Class.new)
+    expect {
+      blank_operation.settings_constructor(:nope)
+    }.to raise_error(Teckel::MissingConfigError, "Missing settings_constructor config for #{blank_operation}")
+
+    expect {
+      blank_operation.settings_constructor
+    }.to raise_error(Teckel::MissingConfigError, "Missing settings_constructor config for #{blank_operation}")
+  end
+
+  describe "result" do
+    specify "default result config" do
+      expect(blank_operation.result).to eq(Teckel::Operation::ValueResult)
+    end
+
+    specify "default result_constructor" do
+      expect(blank_operation.result_constructor).to eq(Teckel::Operation::ValueResult.method(:[]))
+    end
+
+    specify "default result_constructor with settings config set" do
+      result_klass = OpenStruct.new
+      blank_operation.result(result_klass)
+
+      expect(blank_operation.result_constructor).to eq(result_klass.method(:[]))
+    end
+
+    specify "unsupported constructor method" do
+      blank_operation.result(Class.new)
+      expect {
+        blank_operation.result_constructor(:nope)
+      }.to raise_error(Teckel::MissingConfigError, "Missing result_constructor config for #{blank_operation}")
+
+      expect {
+        blank_operation.result_constructor
+      }.to raise_error(Teckel::MissingConfigError, "Missing result_constructor config for #{blank_operation}")
+    end
+
+    specify "with result class as constant" do
+      result_klass = OpenStruct.new
+      blank_operation.const_set(:Result, result_klass)
+
+      expect(blank_operation.result).to eq(result_klass)
+      expect(blank_operation.result_constructor).to eq(result_klass.method(:[]))
+    end
+  end
+
+  describe "result!" do
+    specify "default result config" do
+      blank_operation.result!
+      expect(blank_operation.result).to eq(Teckel::Operation::Result)
+    end
+  end
+end

--- a/spec/operation/config_spec.rb
+++ b/spec/operation/config_spec.rb
@@ -35,7 +35,12 @@ RSpec.describe Teckel::Operation do
     end
 
     specify "without settings class, with settings constructor as proc" do
-      settings_const = ->(sets) { sets.to_h { |k, v| [k.to_s, v.to_i] } }
+      settings_const = if RUBY_VERSION < '2.6.0'
+        ->(sets) { sets.map { |k, v| [k.to_s, v.to_i] }.to_h }
+      else
+        ->(sets) { sets.to_h { |k, v| [k.to_s, v.to_i] } }
+      end
+
       operation.settings_constructor(settings_const)
 
       expect(operation.settings).to eq(Teckel::Contracts::None)

--- a/spec/operation/contract_trace_spec.rb
+++ b/spec/operation/contract_trace_spec.rb
@@ -26,6 +26,7 @@ module TeckelOperationContractTrace
   end
 end
 
+# rubocop:disable Style/EvalWithLocation
 # Hack to get reliable stack traces
 eval <<~RUBY, binding, "operation_success_error.rb"
   module TeckelOperationContractTrace
@@ -77,6 +78,7 @@ eval <<~RUBY, binding, "operation_input_error.rb"
     end
   end
 RUBY
+# rubocop:enable Style/EvalWithLocation
 
 RSpec.describe Teckel::Operation do
   context "contract errors include meaningful trace" do

--- a/spec/operation/default_settings_spec.rb
+++ b/spec/operation/default_settings_spec.rb
@@ -89,6 +89,32 @@ RSpec.describe Teckel::Operation do
           default_settings!(:default_value)
         end
       )
+
+      it_behaves_like(
+        "operation with default settings",
+        Class.new(TeckelOperationDefaultSettings::BaseOperation) do
+          settings Struct.new(:injected)
+
+          default_settings!("default_value")
+
+          output_constructor ->(out) { out&.to_sym }
+        end
+      )
+    end
+
+    describe "with default constructor and simple Settings class responding to passed default setting" do
+      it_behaves_like(
+        "operation with default settings",
+        Class.new(TeckelOperationDefaultSettings::BaseOperation) do
+          settings(Struct.new(:injected) do
+            def self.default
+              new(:default_value)
+            end
+          end)
+
+          default_settings!(:default)
+        end
+      )
     end
   end
 end

--- a/spec/operation/result_spec.rb
+++ b/spec/operation/result_spec.rb
@@ -3,21 +3,15 @@
 RSpec.describe Teckel::Operation::Result do
   let(:failure_value) { "some error" }
   let(:failed_result) { Teckel::Operation::Result.new(failure_value, false) }
-  let(:failed_nil_result) { Teckel::Operation::Result.new(failure_value, nil) }
 
   let(:success_value) { "some success" }
   let(:successful_result) { Teckel::Operation::Result.new(success_value, true) }
-  let(:successful_1_result) { Teckel::Operation::Result.new(success_value, 1) }
 
   it { expect(successful_result.successful?).to eq(true) }
-  it { expect(successful_1_result.successful?).to eq(true) }
   it { expect(failed_result.successful?).to eq(false) }
-  it { expect(failed_nil_result.successful?).to eq(false) }
 
   it { expect(successful_result.failure?).to eq(false) }
-  it { expect(successful_1_result.failure?).to eq(false) }
   it { expect(failed_result.failure?).to eq(true) }
-  it { expect(failed_nil_result.failure?).to eq(true) }
 
   it { expect(successful_result.value).to eq(success_value) }
   it { expect(failed_result.value).to eq(failure_value) }

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -331,8 +331,7 @@ RSpec.describe Teckel::Operation do
     end
 
     it "uses injected data" do
-      result =
-        TeckelOperationInjectSettingsTest::MyOperation.
+      result = TeckelOperationInjectSettingsTest::MyOperation.
         with(injected: [:stuff]).
         call
 
@@ -342,10 +341,10 @@ RSpec.describe Teckel::Operation do
     end
 
     specify "calling `with` multiple times raises an error" do
-      op = TeckelOperationInjectSettingsTest::MyOperation.with(injected: :stuff_1)
+      op = TeckelOperationInjectSettingsTest::MyOperation.with(injected: :stuff1)
 
       expect {
-        op.with(more: :stuff_2)
+        op.with(more: :stuff2)
       }.to raise_error(Teckel::Error, "Operation already has settings assigned.")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,15 @@
 require "bundler/setup"
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'
-  require 'simplecov_json_formatter'
-  SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+
+  SimpleCov.formatter = case ENV['SIMPLECOV']&.downcase
+  when 'html'
+    SimpleCov::Formatter::HTMLFormatter
+  else
+    require 'simplecov_json_formatter'
+    SimpleCov::Formatter::JSONFormatter
+  end
+
   SimpleCov.start do
     add_filter %r{^/spec/}
   end

--- a/teckel.gemspec
+++ b/teckel.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "mutant-rspec"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "yard-doctest"
 end


### PR DESCRIPTION
- Internal refactoring to implement mutant suggestions
- `Teckel::Operation::Result` no longer converts the `successful` value to boolean.
- Adds some tests to cover some mutations


 